### PR TITLE
Ignore vscode and metals files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ tip-sessions
 
 # Inox smt debug folder
 smt-sessions
+
+# VSCode and scala-metals plugin files
+.vscode
+.metals


### PR DESCRIPTION
I guess a lot of people use vscode / metals so this would help in avoiding to commit unwanted files and have a clearer `git status`