### PR TITLE
Make the tests compile with Scala 3

### DIFF
--- a/Fulcrum/Fulcrum.scala
+++ b/Fulcrum/Fulcrum.scala
@@ -10,11 +10,11 @@ object Fulcrum {
     l match {
       case Nil() => BigInt(0)
       case Cons(x, xs) => x + sum(xs)
-    } 
+    }
   }
 
   def abs(x: BigInt) = {
-    if(x > 0) x 
+    if(x > 0) x
     else -x
   }
 
@@ -26,7 +26,7 @@ object Fulcrum {
       case Cons(x, xs) =>
         if(i > 0) lemmaTailDrop(xs, i - 1)
     }
-    l.drop(i + 1) == l.drop(i).tail 
+    l.drop(i + 1) == l.drop(i).tail
   } holds
 
   def lemmaHeadDrop(l: List[BigInt], i: BigInt): Boolean = {
@@ -120,7 +120,7 @@ object Fulcrum {
 
   def fulcrum(l: List[BigInt]) = {
     val s = sum(l)
-    aux(l, 0, 0, abs(s), 0, s, l) 
+    aux(l, 0, 0, abs(s), 0, s, l)
   } ensuring(res => res._1 >= 0 && res._1 <= l.size && isFulcrum(l, res._1, res._2))
 
   @ignore def main(args: Array[String]): Unit = {
@@ -129,9 +129,9 @@ object Fulcrum {
     val l3: List[BigInt] = List(-3, 1, 0)
     val l4: List[BigInt] = List(7, 3, 4, 5, 2, 1, -3)
 
-    println(l1, Fulcrum.fulcrum(l1))
-    println(l2, Fulcrum.fulcrum(l2))
-    println(l3, Fulcrum.fulcrum(l3))
-    println(l4, Fulcrum.fulcrum(l4))
+    println((l1, Fulcrum.fulcrum(l1)))
+    println((l2, Fulcrum.fulcrum(l2)))
+    println((l3, Fulcrum.fulcrum(l3)))
+    println((l4, Fulcrum.fulcrum(l4)))
   }
 }

--- a/data-structures/amortized-queue/AmortizedQueue.scala
+++ b/data-structures/amortized-queue/AmortizedQueue.scala
@@ -4,7 +4,7 @@ import stainless.equations._
 
 abstract class Queue[A] {
 
-  def enqueue(a: A) = (??? : Queue[A])
+  def enqueue(a: A): Queue[A] = (??? : Queue[A])
     .ensuring(res =>
     res.toList == this.toList ++ List(a))
 
@@ -18,9 +18,9 @@ abstract class Queue[A] {
 }
 
 case class SimpleQueue[A](l: List[A]) extends Queue[A] {
-  def enqueue(a: A) = SimpleQueue(l ++ List(a))
+  def enqueue(a: A): SimpleQueue[A] = SimpleQueue(l ++ List(a))
 
-  def dequeue = l match {
+  def dequeue: Option[(A, Queue[A])] = l match {
     case Nil() => None()
     case Cons(x, xs) => Some((x, SimpleQueue(xs)))
   }
@@ -30,7 +30,7 @@ case class SimpleQueue[A](l: List[A]) extends Queue[A] {
 
 
 case class AmortizedQueue[A](front: List[A], rear: List[A]) extends Queue[A] {
-  def enqueue(a: A) = {
+  def enqueue(a: A): AmortizedQueue[A] = {
     val res = AmortizedQueue(front, a :: rear)
     (
       res.toList                         ==:| trivial |:
@@ -43,7 +43,7 @@ case class AmortizedQueue[A](front: List[A], rear: List[A]) extends Queue[A] {
     res
   }
 
-  def dequeue = front match {
+  def dequeue: Option[(A, Queue[A])] = front match {
     case Nil() =>
       rear.reverse match {
         case Nil() => None()
@@ -56,7 +56,7 @@ case class AmortizedQueue[A](front: List[A], rear: List[A]) extends Queue[A] {
 }
 
 /*
-=== Functional Queues === 
+=== Functional Queues ===
 
 Recall that a queue allows taking elements from the **front** and adding elements to the **end**.  Queues are expected to implement these operations in //about constant// time. Here we are going to implement and prove correct a //purely functional// queue, which means that it does not use mutation. The benefit is that we can prove such implementations correct much more easily and, moreover, even after adding or removing an element we can continue to access the previous version of the queue. On the flip side, it means that a simple imperative implementation (such as a doubly linked list with a tail pointer) is out of question. Instead, we use functional lists. A simplest functional approach would be to implement dequeue as list head and implement enqueue as appending a single element to the end of the list. Unfortunately, this would make enqueue linear in the size of the queue. Conversely, if we decided to implement dequeue by removing from the end of a list, then the dequeue would take linear time, instead of constant. A solution is instead to use two lists: one for removing and one for adding. When the list from which remove gets empty, we need to add elements from the other list. We do this by reversing the list, which is good on average, because we do it only once for every element we put into the queue.
 

--- a/data-structures/amortized-queue/Queue2.scala
+++ b/data-structures/amortized-queue/Queue2.scala
@@ -100,8 +100,6 @@ object QueueSpecs {
   def enqueueAndFront[A](queue: Queue2[A], elem: A) : Unit = {
     if (queue.isEmpty)
       assert(queue.enqueue(elem).head == elem)
-    else
-      true
   }
 
   def enqueueDequeueThrice[A](queue: Queue2[A], e1: A, e2: A, e3: A): Unit = {
@@ -115,7 +113,6 @@ object QueueSpecs {
       val q5 = q4.tail
       val e3prime = q5.head
       assert(e1 == e1prime && e2 == e2prime && e3 == e3prime)
-    } else
-      true
+    }
   }
 }

--- a/extended-gcd/ExtendedEuclidGCD.scala
+++ b/extended-gcd/ExtendedEuclidGCD.scala
@@ -4,17 +4,17 @@ import stainless.annotation._
 
 object ExtendedEuclidGCD {
   @inline
-  def exists[T](p: T => Boolean) = !forall((x: T) => !p(x))
+  def exists[T](p: T => Boolean) = !forall[T](x => !p(x))
 
   def divides(x: BigInt, y: BigInt) = {
-    exists((k: BigInt) => y == k * x)
+    exists[BigInt](k => y == k * x)
   }
 
   def eliminationExists[T](p: T => Boolean): T = {
-    require(exists((e: T) => p(e)))
+    require(exists[T](p))
 
-    choose((e: T) => p(e))
-  } ensuring (p)
+    choose[T](e => p(e))
+  }.ensuring(p)
 
   def introductionExists[T](t: T, p: T => Boolean): Boolean = {
     require(p(t))
@@ -29,13 +29,13 @@ object ExtendedEuclidGCD {
   def euclidOneStep(a: BigInt, b: BigInt, r: BigInt) = {
     require(a > 0 && b > 0 && divides(r, b) && divides(r, a - (a / b) * b))
 
-    val i = eliminationExists((k: BigInt) => b == k * r)
-    val j = eliminationExists((k: BigInt) => ((a - (a / b) * b) == k * r))
+    val i = eliminationExists[BigInt](k => b == k * r)
+    val j = eliminationExists[BigInt](k => ((a - (a / b) * b) == k * r))
 
     val c: BigInt = a / b
 
     assert(a == (j + c * i) * r)
-    assert(introductionExists(j + c * i, (k: BigInt) => a == k * r))
+    assert(introductionExists[BigInt](j + c * i, k => a == k * r))
 
     divides(r, a)
   }.holds
@@ -62,11 +62,11 @@ object ExtendedEuclidGCD {
     val (r, x, y) = euclid(a, b)
 
     b match {
-      case BigInt(0) => 
-        assert(introductionExists(BigInt(1), (k: BigInt) => a == k * a))
-        assert(introductionExists(BigInt(0), (k: BigInt) => 0 == k * a))
+      case BigInt(0) =>
+        assert(introductionExists[BigInt](BigInt(1), k => a == k * a))
+        assert(introductionExists[BigInt](BigInt(0), k => 0 == k * a))
         gcd(a, b, r, x, y)
-      case _ => 
+      case _ =>
         assert(euclidCorrectness(b, a - (a / b) * b))
         assert(euclidOneStep(a, b, r))
         gcd(a, b, r, x, y)

--- a/extended-gcd/MoreExtendedEuclidGCD.scala
+++ b/extended-gcd/MoreExtendedEuclidGCD.scala
@@ -3,8 +3,8 @@ import stainless.annotation._
 
 object MoreExtendedEuclidGCD {
   case class Result(gcd: BigInt, // GCD value
-		    ka: BigInt, kb: BigInt,  // witnesses for divisibility (quotients)
-		    x: BigInt, y: BigInt)    // witnesses that ka,kb are mutually prime
+        ka: BigInt, kb: BigInt,  // witnesses for divisibility (quotients)
+        x: BigInt, y: BigInt)    // witnesses that ka,kb are mutually prime
 
   def gcd(a: BigInt, b: BigInt, r: Result): Boolean = {
     a == r.ka * r.gcd &&

--- a/fp-principles/huffman-coding/Huffman.scala
+++ b/fp-principles/huffman-coding/Huffman.scala
@@ -123,10 +123,10 @@ object Huffman {
       }
     }
 
-    def isDistinctList(list: List[CodeTree]): Boolean = {
+    def isDistinctCodecList(list: List[CodeTree]): Boolean = {
       decreases(list)
       list match {
-        case x::xs => xs.forall(elem => (elem.chars & x.chars) == Set.empty[Char]) && isDistinctList(xs)
+        case x::xs => xs.forall(elem => (elem.chars & x.chars) == Set.empty[Char]) && isDistinctCodecList(xs)
         case _ => true
       }
     }
@@ -389,7 +389,7 @@ object Huffman {
     def consistent(tree: CodeTree): Boolean = {
       decreases(tree)
       tree match{
-        case Fork(left, right) => consistent(left) && consistent(right) && isDistinctList(List(left, right))
+        case Fork(left, right) => consistent(left) && consistent(right) && isDistinctCodecList(List(left, right))
         case Leaf(char, weight) => true
       }
     }
@@ -397,7 +397,7 @@ object Huffman {
     def consistent(trees: List[CodeTree]): Boolean = {
       decreases(trees)
       if (trees.size == 0) true
-      else consistent(trees.head) && consistent(trees.tail) && isDistinctList(trees)
+      else consistent(trees.head) && consistent(trees.tail) && isDistinctCodecList(trees)
     }
 
     def depth(tree: CodeTree, char: Char): BigInt = {

--- a/gcd/gcd.scala
+++ b/gcd/gcd.scala
@@ -7,21 +7,21 @@ import stainless.annotation._
 object GCD {
 
   @inline
-  def exists[T](p: T => Boolean) = ! forall((x: T) => !p(x))
+  def exists[T](p: T => Boolean) = !forall[T](x => !p(x))
 
   def divides(x: BigInt, y: BigInt) = {
-    exists ((k: BigInt) => y == k*x)
+    exists[BigInt](k => y == k*x)
   }
 
   def elimination_exists[T](p: T => Boolean): T = {
-    require(exists ((e: T) => p(e)))
+    require(exists[T](p))
 
-    choose((e: T) => p(e))
-  } ensuring(p)
+    choose[T](e => p(e))
+  }.ensuring(p)
 
   @inline @opaque
   def elimination_forall[T](p: T => Boolean, t: T) = {
-    require(forall ((e: T) => p(e)))
+    require(forall[T](p))
 
   }.ensuring(_ => p(t))
 
@@ -49,10 +49,10 @@ object GCD {
   def divides_combination(x: BigInt, a: BigInt, b: BigInt, c: BigInt, d: BigInt) = {
     require(divides(x,a) && divides(x,b))
 
-    val i = elimination_exists((k: BigInt) => a == k*x)
-    val j = elimination_exists((k: BigInt) => b == k*x)
+    val i = elimination_exists[BigInt](k => a == k*x)
+    val j = elimination_exists[BigInt](k => b == k*x)
 
-    introduction_exists(c*i + d*j, (k: BigInt) => c*a + b*d == k*x)
+    introduction_exists[BigInt](c*i + d*j, k => c*a + b*d == k*x)
 
   }.ensuring(_ => divides(x,c*a + d*b))
 
@@ -64,8 +64,8 @@ object GCD {
     assert(divides(r2, (a/b)*b + 1*(a-(a/b)*b)))
     assert(divides(r2,a))
 
-    assert(forall ((r2: BigInt) => smallerDivider(r2,r,a,b)))
-    elimination_forall((r2: BigInt) => smallerDivider(r2,r,a,b), r2)
+    assert(forall[BigInt](r2 => smallerDivider(r2,r,a,b)))
+    elimination_forall[BigInt](r2 => smallerDivider(r2,r,a,b), r2)
     assert(smallerDivider(r2,r,a,b))
 
     assert( (divides(r2,a) && divides(r2,b)) ==> r2 <= r)
@@ -96,13 +96,13 @@ object GCD {
     require(b > 0 && gcd(a,b,r))
 
     assert(
-      forall((r2: BigInt) => {
+      forall[BigInt](r2 => {
         lemma2_onestep(a,b,r2,r)
         smallerDivider(r2,r,b,a-(a/b)*b)
       })
     )
 
-  }.ensuring(_ => forall((r2: BigInt) => smallerDivider(r2,r,b,a-(a/b)*b)))
+  }.ensuring(_ => forall[BigInt](r2 => smallerDivider(r2,r,b,a-(a/b)*b)))
 
   @opaque @inlineOnce
   def euclid_onestep(a: BigInt, b: BigInt, r: BigInt) = {
@@ -114,19 +114,19 @@ object GCD {
 
     lemma3_onestep(a,b,r)
 
-    assert(forall((r2: BigInt) => smallerDivider(r2,r,b,a-(a/b)*b)))
+    assert(forall[BigInt](r2 => smallerDivider(r2,r,b,a-(a/b)*b)))
 
   }.ensuring(_ => gcd(b, a - (a/b)*b, r))
 
   @opaque @inlineOnce
   def divides_zero(a: BigInt) = {
-    introduction_exists(BigInt(0), (k: BigInt) => 0 == k*a)
+    introduction_exists[BigInt](BigInt(0), k => 0 == k*a)
 
   }.ensuring(_ => divides(a,0))
 
   @opaque @inlineOnce
   def divides_reflexive(a: BigInt) = {
-    introduction_exists(BigInt(1), (k: BigInt) => a == k*a)
+    introduction_exists[BigInt](BigInt(1), k => a == k*a)
 
   }.ensuring(_ => divides(a, a))
 
@@ -139,8 +139,8 @@ object GCD {
   def gcd_unicity(a: BigInt, b: BigInt, r1: BigInt, r2: BigInt) = {
     require(gcd(a,b,r1) && gcd(a,b,r2))
 
-    elimination_forall((x: BigInt) => smallerDivider(x,r1,a,b), r2)
-    elimination_forall((x: BigInt) => smallerDivider(x,r2,a,b), r1)
+    elimination_forall[BigInt](x => smallerDivider(x,r1,a,b), r2)
+    elimination_forall[BigInt](x => smallerDivider(x,r2,a,b), r1)
     assert((divides(r2,a) && divides(r2,b)) ==> r2 <= r1)
     assert((divides(r1,a) && divides(r1,b)) ==> r1 <= r2)
 
@@ -151,7 +151,7 @@ object GCD {
     require(a > 0)
 
   }.ensuring(_ =>
-    forall((r2: BigInt) => smallerDivider(r2, a, a, 0))
+    forall[BigInt](r2 => smallerDivider(r2, a, a, 0))
   )
 
   def gcd_zero_reflexive(a: BigInt) = {

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-STAINLESS_SCALAC="stainless-scalac --config-file=stainless.conf.nightly"
+FRONTEND="stainless-scalac"
+if [[ "$#" = 1 ]]; then
+  FRONTEND="$1"
+fi
+STAINLESS="$FRONTEND --config-file=stainless.conf.nightly"
 
 function run_tests {
   project=$1
@@ -8,15 +12,15 @@ function run_tests {
 
   echo ""
   echo "------------------------------------------------------------------------------------------"
-  echo "Running '$STAINLESS_SCALAC $option' on bolts project: $project..."
-  echo "$ find $project -name '*.scala' -exec $STAINLESS_SCALAC $option {} +"
-  find "$project" -name '*.scala' -exec $STAINLESS_SCALAC "$@" {} +
+  echo "Running '$STAINLESS $option' on bolts project: $project..."
+  echo "$ find $project -name '*.scala' -exec $STAINLESS $option {} +"
+  find "$project" -name '*.scala' -exec $STAINLESS "$@" {} +
 
   status=$?
 
   if [ $status -ne 0 ]
   then
-    echo "'$STAINLESS_SCALAC $option' failed on bolts project: $project."
+    echo "'$STAINLESS $option' failed on bolts project: $project."
     echo "------------------------------------------------------------------------------------------"
     echo ""
     exit 1

--- a/sorted-array/SortedArray.scala
+++ b/sorted-array/SortedArray.scala
@@ -3,7 +3,7 @@ import stainless.lang.StaticChecks.WhileDecorations
 import stainless.lang.StaticChecks.assert
 import stainless.math._
 import stainless.proof.check
-import stainless.annotation._
+import stainless.annotation.{ghost => ghostAnnot, _}
 import scala.Predef.{ genericArrayOps => _, genericWrapArray => _, assume => _, _ }
 import stainless.lang.ArrayUpdating
 
@@ -24,7 +24,7 @@ object SortedArray {
     else order.leq(array(l)._1, elem) && allSmaller(array, order, elem, l-1)
   }
 
-  @pure @opaque @ghost
+  @pure @opaque @ghostAnnot
   def getSmaller[K, @mutable T](array: Array[(K, T)], order: TotalOrder[K], elem: K, l: Int, i: Int): Unit = {
     require(0 <= i && i <= l && l < array.length && allSmaller(array, order, elem, l))
     decreases(l - i)
@@ -62,7 +62,7 @@ object SortedArray {
       true
   }
 
-  @pure @opaque @ghost
+  @pure @opaque @ghostAnnot
   def isSortedRangeSwap[K, @mutable T](array: Array[(K, T)], order: TotalOrder[K], i: Int, j: Int): Unit = {
     require(0 <= i && 0 < j && j < array.length && isSortedRange(array, order, i, j))
     decreases(max(0, j-i))
@@ -79,7 +79,7 @@ object SortedArray {
     isSortedRange(array.updated(j, array(j-1)).updated(j-1, array(j)), order, i, j-1)
   )
 
-  @pure @opaque @ghost @inlineOnce
+  @pure @opaque @ghostAnnot @inlineOnce
   def isSortedRangeSwap2[K, @mutable T](
     array: Array[(K, T)], order: TotalOrder[K],
     i: Int, j: Int,
@@ -104,7 +104,7 @@ object SortedArray {
     isSortedRange(array.updated(k, array(l)).updated(l, array(k)), order, i, j)
   )
 
-  @pure @opaque @ghost @inlineOnce
+  @pure @opaque @ghostAnnot @inlineOnce
   def isSortedRangeSame[K, @mutable T](
     array: Array[(K, T)], order: TotalOrder[K],
     i1: Int, j1: Int, i2: Int, j2: Int
@@ -118,13 +118,13 @@ object SortedArray {
     isSortedRange(array, order, i2, j2)
   )
 
-  @pure @opaque @ghost @inline
+  @pure @opaque @ghostAnnot @inline
   def arrayGetSameIndex2[@mutable T](array: Array[T], i: Int, j: Int): Unit = {
     require(0 <= i && i < array.length - 1 && i == j)
 
   }.ensuring(_ => array(i+1) == array(j+1))
 
-  @pure @opaque @ghost
+  @pure @opaque @ghostAnnot
   def sortedRangePair[K, @mutable T](array: Array[(K, T)], order: TotalOrder[K], l: Int, i: Int, j: Int): Unit = {
     require(0 <= i && 0 <= j)
     require(isSortedRange(array, order, i, j))
@@ -148,7 +148,7 @@ object SortedArray {
     order.leq(array(l)._1, array(l + 1)._1)
   )
 
-  @pure @opaque @ghost
+  @pure @opaque @ghostAnnot
   def sortedPair[K, @mutable T](array: Array[(K, T)], order: TotalOrder[K], l: Int): Unit = {
     require(
       isSorted(array, order) &&
@@ -161,7 +161,7 @@ object SortedArray {
     order.leq(array(l)._1, array(l + 1)._1)
   )
 
-  @pure @opaque @ghost
+  @pure @opaque @ghostAnnot
   def sortedAllSmaller[K, @mutable T](array: Array[(K, T)], order: TotalOrder[K], elem: K, l: Int): Unit = {
     require(
       isSorted(array, order) &&
@@ -181,7 +181,7 @@ object SortedArray {
     allSmaller(array, order, elem, l)
   )
 
-  @pure @opaque @ghost
+  @pure @opaque @ghostAnnot
   def sortedAllLarger[K, @mutable T](array: Array[(K, T)], order: TotalOrder[K], elem: K, l: Int): Unit = {
     require(
       isSorted(array, order) &&
@@ -203,7 +203,7 @@ object SortedArray {
     allLarger(array, order, elem, l)
   )
 
-  @opaque @ghost @pure
+  @opaque @ghostAnnot @pure
   def insertSortedRange[K, @mutable T](array: Array[(K, T)], order: TotalOrder[K], h: Int, elem: (K, T), i: Int): Unit = {
     require(0 <= h && h < array.length)
     require(isSortedRange(array, order, 0, h))
@@ -239,7 +239,7 @@ object SortedArray {
     isSortedRange(array.updated(h, elem), order, i, array.length - 1)
   }
 
-  @opaque @ghost @pure @inlineOnce
+  @opaque @ghostAnnot @pure @inlineOnce
   def insertSorted[K, @mutable T](array: Array[(K, T)], order: TotalOrder[K], h: Int, elem: (K, T)): Unit = {
     require(0 <= h && h < array.length)
     require(isSortedRange(array, order, 0, h))

--- a/sorted-array/TotalOrder.scala
+++ b/sorted-array/TotalOrder.scala
@@ -1,31 +1,31 @@
-import stainless.annotation._
+import stainless.annotation.{ghost => ghostAnnot, _}
 import stainless.lang._
 
 // trait TotalOrder[A] {
 //   def leq(x: A, y: A): Boolean
 
-//   @ghost
+//   @ghostAnnot
 //   def reflexivityLaw(x: A): Unit = {
 //     (??? : Unit)
 //   }.ensuring { _ =>
 //     leq(x, x)
 //   }
 
-//   @ghost
+//   @ghostAnnot
 //   def antiSymmetryLaw(x: A, y: A): Unit = {
 //     (??? : Unit)
 //   }.ensuring { _ =>
 //     (leq(x, y) && leq(y, x)) ==> (x == y)
 //   }
 
-//   @ghost
+//   @ghostAnnot
 //   def transitivityLaw(x: A, y: A, z: A): Unit = {
 //     (??? : Unit)
 //   }.ensuring { _ =>
 //     (leq(x, y) && leq(y, z)) ==> leq(x, z)
 //   }
 
-//   @ghost
+//   @ghostAnnot
 //   def totalityLaw(x: A, y: A): Unit = {
 //     (??? : Unit)
 //   }.ensuring { _ =>
@@ -37,28 +37,28 @@ import stainless.lang._
 // FIXME: currently unsound because of the `???`
 // Make sure these propertes hold when instantiating a new `TotalOrder`
 case class TotalOrder[A](leq: (A, A) => Boolean) {
-  @ghost
+  @ghostAnnot
   def reflexivityLaw(x: A): Unit = {
     (??? : Unit)
   }.ensuring { _ =>
     leq(x, x)
   }
 
-  @ghost
+  @ghostAnnot
   def antiSymmetryLaw(x: A, y: A): Unit = {
     (??? : Unit)
   }.ensuring { _ =>
     (leq(x, y) && leq(y, x)) ==> (x == y)
   }
 
-  @ghost
+  @ghostAnnot
   def transitivityLaw(x: A, y: A, z: A): Unit = {
     (??? : Unit)
   }.ensuring { _ =>
     (leq(x, y) && leq(y, z)) ==> leq(x, z)
   }
 
-  @ghost
+  @ghostAnnot
   def totalityLaw(x: A, y: A): Unit = {
     (??? : Unit)
   }.ensuring { _ =>


### PR DESCRIPTION
The change to the `run-tests.sh` script allows to specify the frontend to use (by default, it uses `stainless-scalac`). For instance, if we would like to run the tests with the Scala 3 frontend, we would run `./run-tests stainless-dotty`.