### PR TITLE
Use static checks in the lexers

### DIFF
--- a/lexers/dfa/ListUtils.scala
+++ b/lexers/dfa/ListUtils.scala
@@ -1,12 +1,13 @@
 /** Author: Samuel Chassot
   */
-  
+
 import stainless.annotation._
 import stainless.collection._
 import stainless.equations._
 import stainless.lang._
 import stainless.proof.check
 import scala.annotation.tailrec
+import stainless.lang.StaticChecks._
 
 object ListUtils {
   def isPrefix[B](prefix: List[B], l: List[B]): Boolean = {
@@ -74,7 +75,7 @@ object ListUtils {
       case _                                                                   => ()
     }
 
-  } ensuring (ListSpecs.subseq(l1, l2))
+  } ensuring (_ => ListSpecs.subseq(l1, l2))
 
   @inlineOnce
   @opaque
@@ -82,7 +83,7 @@ object ListUtils {
     require(l.contains(e))
     require(l.head != e)
 
-  } ensuring (l.tail.contains(e))
+  } ensuring (_ => l.tail.contains(e))
 
   @inlineOnce
   @opaque
@@ -107,7 +108,7 @@ object ListUtils {
     }
     assert(l.tail.contains(e2))
 
-  } ensuring (l.tail.contains(e2))
+  } ensuring (_ => l.tail.contains(e2))
 
   @inlineOnce
   @opaque
@@ -123,7 +124,7 @@ object ListUtils {
     } else {
       lemmaSameIndexThenSameElement(l.tail, e1, e2)
     }
-  } ensuring (e1 == e2)
+  } ensuring (_ => e1 == e2)
 
   @inlineOnce
   @opaque
@@ -133,7 +134,7 @@ object ListUtils {
     require(l.head == e1)
     require(getIndex(l, e1) < getIndex(l, e2))
 
-  } ensuring (l.tail.contains(e2))
+  } ensuring (_ => l.tail.contains(e2))
 
   @inlineOnce
   @opaque
@@ -144,7 +145,7 @@ object ListUtils {
     if (l.tail.head != e) {
       lemmaNotHeadSoGetIndexTailIsMinusOne(l.tail, e)
     }
-  } ensuring (getIndex(l, e) == getIndex(l.tail, e) + 1)
+  } ensuring (_ => getIndex(l, e) == getIndex(l.tail, e) + 1)
 
   @inlineOnce
   @opaque
@@ -154,7 +155,7 @@ object ListUtils {
       case Cons(hd, tl) => lemmaIsPrefixRefl(tl, l2.tail)
       case Nil()        => ()
     }
-  } ensuring (isPrefix(l1, l2))
+  } ensuring (_ => isPrefix(l1, l2))
 
   @inlineOnce
   @opaque
@@ -163,7 +164,7 @@ object ListUtils {
       case Cons(hd, tl) => lemmaConcatTwoListThenFirstIsPrefix(tl, l2)
       case Nil()        => ()
     }
-  } ensuring (isPrefix(l1, l1 ++ l2))
+  } ensuring (_ => isPrefix(l1, l1 ++ l2))
 
   @inlineOnce
   @opaque
@@ -179,7 +180,7 @@ object ListUtils {
       case Cons(hd, tl) => lemmaLongerPrefixContainsHeadOfSuffixOfSmallerPref(tl, s1, p2.tail, l.tail)
       case Nil()        => ()
     }
-  } ensuring (p2.contains(s1.head))
+  } ensuring (_ => p2.contains(s1.head))
 
   @inlineOnce
   @opaque
@@ -190,7 +191,7 @@ object ListUtils {
       case Cons(hd, tl) => lemmaConcatAssociativity(tl, elmt, l2, tot.tail)
       case Nil()        => ()
     }
-  } ensuring (l1 ++ (List(elmt) ++ l2) == tot)
+  } ensuring (_ => l1 ++ (List(elmt) ++ l2) == tot)
 
   @inlineOnce
   @opaque
@@ -206,7 +207,7 @@ object ListUtils {
       case Nil() => ()
     }
 
-  } ensuring ((l1 ++ l2) ++ l3 == l1 ++ (l2 ++ l3))
+  } ensuring (_ => (l1 ++ l2) ++ l3 == l1 ++ (l2 ++ l3))
 
   @inlineOnce
   @opaque
@@ -216,7 +217,7 @@ object ListUtils {
       case Cons(hd, tl) => lemmaRemoveLastConcatenatedPrefixStillPrefix(tl, elmt, tot.tail)
       case Nil()        => ()
     }
-  } ensuring (isPrefix(l, tot))
+  } ensuring (_ => isPrefix(l, tot))
 
   @inlineOnce
   @opaque
@@ -229,7 +230,7 @@ object ListUtils {
       case Nil()        => ()
     }
 
-  } ensuring (isPrefix(p, removeLast(l)))
+  } ensuring (_ => isPrefix(p, removeLast(l)))
 
   @inlineOnce
   @opaque
@@ -239,13 +240,13 @@ object ListUtils {
       case Cons(hd, tl) => lemmaPrefixStaysPrefixWhenAddingToSuffix(tl, l.tail, suffix)
       case Nil()        => ()
     }
-  } ensuring (isPrefix(p, l ++ suffix))
+  } ensuring (_ => isPrefix(p, l ++ suffix))
 
   @inlineOnce
   @opaque
   def lemmaRemoveLastPrefixDecreasesSize[B](l: List[B]): Unit = {
     require(l.size > 0)
-  } ensuring (removeLast(l).size < l.size)
+  } ensuring (_ => removeLast(l).size < l.size)
 
   @inlineOnce
   @opaque
@@ -259,7 +260,7 @@ object ListUtils {
       case Nil()        => ()
     }
 
-  } ensuring (p1 == p2)
+  } ensuring (_ => p1 == p2)
 
   @inlineOnce
   @opaque
@@ -270,7 +271,7 @@ object ListUtils {
       case Cons(hd, tl) => lemmaRemoveLastFromBothSidePreservesEq(tl, s, l.tail)
       case Nil()        => ()
     }
-  } ensuring (p ++ removeLast(s) == removeLast(l))
+  } ensuring (_ => p ++ removeLast(s) == removeLast(l))
 
   @inlineOnce
   @opaque
@@ -282,7 +283,7 @@ object ListUtils {
       case Cons(hd, tl)    => lemmaRemoveLastFromLMakesItPrefix(tl)
     }
 
-  } ensuring (isPrefix(removeLast(l), l))
+  } ensuring (_ => isPrefix(removeLast(l), l))
 
   @inlineOnce
   @opaque
@@ -297,7 +298,7 @@ object ListUtils {
       case Cons(hd, tl) => lemmaSamePrefixThenSameSuffix(tl, s1, p2.tail, s2, l.tail)
       case Nil()        => ()
     }
-  } ensuring (s1 == s2)
+  } ensuring (_ => s1 == s2)
 
   @inlineOnce
   @opaque
@@ -308,7 +309,7 @@ object ListUtils {
       case (_, Nil()) => ()
       case (l1, l2)   => lemmaIsPrefixThenSmallerEqSize(l1.tail, l2.tail)
     }
-  } ensuring (p.size <= l.size)
+  } ensuring (_ => p.size <= l.size)
 
   @inlineOnce
   @opaque
@@ -319,7 +320,7 @@ object ListUtils {
       case Cons(hd, tl) => lemmaAddHeadSuffixToPrefixStillPrefix(tl, l.tail)
       case Nil()        => ()
     }
-  } ensuring (isPrefix(p ++ List(getSuffix(l, p).head), l))
+  } ensuring (_ => isPrefix(p ++ List(getSuffix(l, p).head), l))
 
   @inlineOnce
   @opaque
@@ -330,7 +331,7 @@ object ListUtils {
       case Cons(hd, tl) => lemmaGetSuffixOnListWithItSelfIsEmpty(tl)
       case Nil()        => ()
     }
-  } ensuring (getSuffix(l, l).isEmpty)
+  } ensuring (_ => getSuffix(l, l).isEmpty)
 
   @inlineOnce
   @opaque
@@ -342,7 +343,7 @@ object ListUtils {
       case Nil()          => ()
     }
 
-  } ensuring ((s1 ++ List(hd2)) ++ tl2 == tot)
+  } ensuring (_ => (s1 ++ List(hd2)) ++ tl2 == tot)
 
   @inlineOnce
   @opaque
@@ -355,7 +356,7 @@ object ListUtils {
       case Cons(hd, tl) => lemmaPrefixFromSameListAndStrictlySmallerThenPrefixFromEachOther(s1.tail, tl, l.tail)
       case Nil()        =>
     }
-  } ensuring (isPrefix(s2, s1))
+  } ensuring (_ => isPrefix(s2, s1))
 
   @inlineOnce
   @opaque
@@ -388,7 +389,7 @@ object ListUtils {
       case Nil()        => ()
       case Cons(hd, tl) => lemmaSubseqRefl(tl)
     }
-  } ensuring (ListSpecs.subseq(l, l))
+  } ensuring (_ => ListSpecs.subseq(l, l))
 
   @inlineOnce
   @opaque
@@ -402,7 +403,7 @@ object ListUtils {
       }
       case Cons(hd, tl) if hd != elmt => lemmaSubseqRefl(l)
     }
-  } ensuring (ListSpecs.subseq(l, Cons(elmt, l)))
+  } ensuring (_ => ListSpecs.subseq(l, Cons(elmt, l)))
 
   @inlineOnce
   @opaque
@@ -442,7 +443,7 @@ object ListUtils {
       case _ => ()
     }
 
-  } ensuring (ListSpecs.subseq(l1, l3))
+  } ensuring (_ => ListSpecs.subseq(l1, l3))
 
   @inlineOnce
   @opaque
@@ -451,7 +452,7 @@ object ListUtils {
       case Cons(hd, tl) => lemmaConcatThenFirstSubseqOfTot(tl, l2)
       case Nil()        => ()
     }
-  } ensuring (ListSpecs.subseq(l1, l1 ++ l2))
+  } ensuring (_ => ListSpecs.subseq(l1, l1 ++ l2))
 
   @inlineOnce
   @opaque
@@ -460,7 +461,7 @@ object ListUtils {
       case Cons(hd, tl) => lemmaConcatThenSecondSubseqOfTot(tl, l2)
       case Nil()        => lemmaSubseqRefl(l2)
     }
-  } ensuring (ListSpecs.subseq(l2, l1 ++ l2))
+  } ensuring (_ => ListSpecs.subseq(l2, l1 ++ l2))
 
   @inlineOnce
   @opaque
@@ -473,7 +474,7 @@ object ListUtils {
       case Cons(hd, tl)            => lemmaConcatTwoListsWhichNotContainThenTotNotContain(tl, l2, b)
       case Nil()                   => ()
     }
-  } ensuring (!(l1 ++ l2).contains(b))
+  } ensuring (_ => !(l1 ++ l2).contains(b))
 
   @inlineOnce
   @opaque
@@ -482,7 +483,7 @@ object ListUtils {
     require(l1 == l1Bis)
     require(l2 == l2Bis)
 
-  } ensuring (l1Bis.forall(b => l2Bis.contains(b)))
+  } ensuring (_ => l1Bis.forall(b => l2Bis.contains(b)))
 
   @inlineOnce
   @opaque
@@ -510,7 +511,7 @@ object ListUtils {
       }
       case Nil() => ()
     }
-  } ensuring (lIn.size <= l.size)
+  } ensuring (_ => lIn.size <= l.size)
 
   @inlineOnce
   @opaque
@@ -526,5 +527,5 @@ object ListUtils {
       case Cons(hd, tl) => lemmaRemoveElmtContainedSizeSmaller(tl, e)
       case Nil()        => check(false)
     }
-  } ensuring ((l - e).size < l.size)
+  } ensuring (_ => (l - e).size < l.size)
 }

--- a/lexers/regex/ListUtils.scala
+++ b/lexers/regex/ListUtils.scala
@@ -1,12 +1,13 @@
 /** Author: Samuel Chassot
   */
-  
+
 import stainless.annotation._
 import stainless.collection._
 import stainless.equations._
 import stainless.lang._
 import stainless.proof.check
 import scala.annotation.tailrec
+import stainless.lang.StaticChecks._
 
 object ListUtils {
   def isPrefix[B](prefix: List[B], l: List[B]): Boolean = {
@@ -64,6 +65,8 @@ object ListUtils {
     }
   }
 
+  @inlineOnce
+  @opaque
   def lemmaConsecutiveSubseqThenSubseq[B](l1: List[B], l2: List[B]): Unit = {
     require(consecutiveSubseq(l1, l2))
     (l1, l2) match {
@@ -72,18 +75,23 @@ object ListUtils {
       case _                                                                   => ()
     }
 
-  } ensuring (ListSpecs.subseq(l1, l2))
+  } ensuring (_ => ListSpecs.subseq(l1, l2))
 
+  @inlineOnce
+  @opaque
   def lemmaContainsAndNotHdThenTlContains[B](l: List[B], e: B): Unit = {
     require(l.contains(e))
     require(l.head != e)
 
-  } ensuring (l.tail.contains(e))
+  } ensuring (_ => l.tail.contains(e))
 
+  @inlineOnce
+  @opaque
   def lemmaGetIndexBiggerAndHeadNotEqThenTailContains[B](l: List[B], e1: B, e2: B): Unit = {
     require(l.contains(e1) && l.contains(e2))
     require(e1 != e2)
     require(getIndex(l, e1) < getIndex(l, e2))
+    decreases(l.size)
 
     l match {
       case Cons(hd, tl) if hd == e1 => lemmaGetIndexBiggerAndHeadEqThenTailContains(l, e1, e2)
@@ -100,8 +108,10 @@ object ListUtils {
     }
     assert(l.tail.contains(e2))
 
-  } ensuring (l.tail.contains(e2))
+  } ensuring (_ => l.tail.contains(e2))
 
+  @inlineOnce
+  @opaque
   def lemmaSameIndexThenSameElement[B](l: List[B], e1: B, e2: B): Unit = {
     require(l.contains(e1))
     require(l.contains(e2))
@@ -114,16 +124,20 @@ object ListUtils {
     } else {
       lemmaSameIndexThenSameElement(l.tail, e1, e2)
     }
-  } ensuring (e1 == e2)
+  } ensuring (_ => e1 == e2)
 
+  @inlineOnce
+  @opaque
   def lemmaGetIndexBiggerAndHeadEqThenTailContains[B](l: List[B], e1: B, e2: B): Unit = {
     require(l.contains(e1) && l.contains(e2))
     require(e1 != e2)
     require(l.head == e1)
     require(getIndex(l, e1) < getIndex(l, e2))
 
-  } ensuring (l.tail.contains(e2))
+  } ensuring (_ => l.tail.contains(e2))
 
+  @inlineOnce
+  @opaque
   def lemmaNotHeadSoGetIndexTailIsMinusOne[B](l: List[B], e: B): Unit = {
     require(l.contains(e))
     require(l.head != e)
@@ -131,23 +145,29 @@ object ListUtils {
     if (l.tail.head != e) {
       lemmaNotHeadSoGetIndexTailIsMinusOne(l.tail, e)
     }
-  } ensuring (getIndex(l, e) == getIndex(l.tail, e) + 1)
+  } ensuring (_ => getIndex(l, e) == getIndex(l.tail, e) + 1)
 
+  @inlineOnce
+  @opaque
   def lemmaIsPrefixRefl[B](l1: List[B], l2: List[B]): Unit = {
     require(l1 == l2)
     l1 match {
       case Cons(hd, tl) => lemmaIsPrefixRefl(tl, l2.tail)
       case Nil()        => ()
     }
-  } ensuring (isPrefix(l1, l2))
+  } ensuring (_ => isPrefix(l1, l2))
 
+  @inlineOnce
+  @opaque
   def lemmaConcatTwoListThenFirstIsPrefix[B](l1: List[B], l2: List[B]): Unit = {
     l1 match {
       case Cons(hd, tl) => lemmaConcatTwoListThenFirstIsPrefix(tl, l2)
       case Nil()        => ()
     }
-  } ensuring (isPrefix(l1, l1 ++ l2))
+  } ensuring (_ => isPrefix(l1, l1 ++ l2))
 
+  @inlineOnce
+  @opaque
   def lemmaLongerPrefixContainsHeadOfSuffixOfSmallerPref[B](p1: List[B], s1: List[B], p2: List[B], l: List[B]): Unit = {
     require(isPrefix(p2, l))
     require(p1 ++ s1 == l)
@@ -160,8 +180,10 @@ object ListUtils {
       case Cons(hd, tl) => lemmaLongerPrefixContainsHeadOfSuffixOfSmallerPref(tl, s1, p2.tail, l.tail)
       case Nil()        => ()
     }
-  } ensuring (p2.contains(s1.head))
+  } ensuring (_ => p2.contains(s1.head))
 
+  @inlineOnce
+  @opaque
   def lemmaConcatAssociativity[B](l1: List[B], elmt: B, l2: List[B], tot: List[B]): Unit = {
     require((l1 ++ List(elmt)) ++ l2 == tot)
     assert(l1 ++ List(elmt) ++ l2 == tot)
@@ -169,8 +191,10 @@ object ListUtils {
       case Cons(hd, tl) => lemmaConcatAssociativity(tl, elmt, l2, tot.tail)
       case Nil()        => ()
     }
-  } ensuring (l1 ++ (List(elmt) ++ l2) == tot)
+  } ensuring (_ => l1 ++ (List(elmt) ++ l2) == tot)
 
+  @inlineOnce
+  @opaque
   def lemmaTwoListsConcatAssociativity[B](
       l1: List[B],
       l2: List[B],
@@ -183,16 +207,20 @@ object ListUtils {
       case Nil() => ()
     }
 
-  } ensuring ((l1 ++ l2) ++ l3 == l1 ++ (l2 ++ l3))
+  } ensuring (_ => (l1 ++ l2) ++ l3 == l1 ++ (l2 ++ l3))
 
+  @inlineOnce
+  @opaque
   def lemmaRemoveLastConcatenatedPrefixStillPrefix[B](l: List[B], elmt: B, tot: List[B]): Unit = {
     require(isPrefix(l ++ List(elmt), tot))
     l match {
       case Cons(hd, tl) => lemmaRemoveLastConcatenatedPrefixStillPrefix(tl, elmt, tot.tail)
       case Nil()        => ()
     }
-  } ensuring (isPrefix(l, tot))
+  } ensuring (_ => isPrefix(l, tot))
 
+  @inlineOnce
+  @opaque
   def lemmaRemoveLastPrefixStillPrefix[B](p: List[B], l: List[B]): Unit = {
     require(!l.isEmpty)
     require(isPrefix(p, l))
@@ -202,20 +230,26 @@ object ListUtils {
       case Nil()        => ()
     }
 
-  } ensuring (isPrefix(p, removeLast(l)))
+  } ensuring (_ => isPrefix(p, removeLast(l)))
 
+  @inlineOnce
+  @opaque
   def lemmaPrefixStaysPrefixWhenAddingToSuffix[B](p: List[B], l: List[B], suffix: List[B]): Unit = {
     require(isPrefix(p, l))
     p match {
       case Cons(hd, tl) => lemmaPrefixStaysPrefixWhenAddingToSuffix(tl, l.tail, suffix)
       case Nil()        => ()
     }
-  } ensuring (isPrefix(p, l ++ suffix))
+  } ensuring (_ => isPrefix(p, l ++ suffix))
 
+  @inlineOnce
+  @opaque
   def lemmaRemoveLastPrefixDecreasesSize[B](l: List[B]): Unit = {
     require(l.size > 0)
-  } ensuring (removeLast(l).size < l.size)
+  } ensuring (_ => removeLast(l).size < l.size)
 
+  @inlineOnce
+  @opaque
   def lemmaIsPrefixSameLengthThenSameList[B](p1: List[B], p2: List[B], l: List[B]): Unit = {
     require(isPrefix(p1, l))
     require(isPrefix(p2, l))
@@ -226,8 +260,10 @@ object ListUtils {
       case Nil()        => ()
     }
 
-  } ensuring (p1 == p2)
+  } ensuring (_ => p1 == p2)
 
+  @inlineOnce
+  @opaque
   def lemmaRemoveLastFromBothSidePreservesEq[B](p: List[B], s: List[B], l: List[B]): Unit = {
     require(p ++ s == l)
     require(!s.isEmpty)
@@ -235,17 +271,22 @@ object ListUtils {
       case Cons(hd, tl) => lemmaRemoveLastFromBothSidePreservesEq(tl, s, l.tail)
       case Nil()        => ()
     }
-  } ensuring (p ++ removeLast(s) == removeLast(l))
+  } ensuring (_ => p ++ removeLast(s) == removeLast(l))
 
+  @inlineOnce
+  @opaque
   def lemmaRemoveLastFromLMakesItPrefix[B](l: List[B]): Unit = {
     require(!l.isEmpty)
+    decreases(l.size)
     l match {
       case Cons(hd, Nil()) => ()
       case Cons(hd, tl)    => lemmaRemoveLastFromLMakesItPrefix(tl)
     }
 
-  } ensuring (isPrefix(removeLast(l), l))
+  } ensuring (_ => isPrefix(removeLast(l), l))
 
+  @inlineOnce
+  @opaque
   def lemmaSamePrefixThenSameSuffix[B](p1: List[B], s1: List[B], p2: List[B], s2: List[B], l: List[B]): Unit = {
     require(isPrefix(p1, l))
     require(isPrefix(p2, l))
@@ -257,8 +298,10 @@ object ListUtils {
       case Cons(hd, tl) => lemmaSamePrefixThenSameSuffix(tl, s1, p2.tail, s2, l.tail)
       case Nil()        => ()
     }
-  } ensuring (s1 == s2)
+  } ensuring (_ => s1 == s2)
 
+  @inlineOnce
+  @opaque
   def lemmaIsPrefixThenSmallerEqSize[B](p: List[B], l: List[B]): Unit = {
     require(isPrefix(p, l))
     (p, l) match {
@@ -266,8 +309,10 @@ object ListUtils {
       case (_, Nil()) => ()
       case (l1, l2)   => lemmaIsPrefixThenSmallerEqSize(l1.tail, l2.tail)
     }
-  } ensuring (p.size <= l.size)
+  } ensuring (_ => p.size <= l.size)
 
+  @inlineOnce
+  @opaque
   def lemmaAddHeadSuffixToPrefixStillPrefix[B](p: List[B], l: List[B]): Unit = {
     require(isPrefix(p, l))
     require(p.size < l.size)
@@ -275,16 +320,21 @@ object ListUtils {
       case Cons(hd, tl) => lemmaAddHeadSuffixToPrefixStillPrefix(tl, l.tail)
       case Nil()        => ()
     }
-  } ensuring (isPrefix(p ++ List(getSuffix(l, p).head), l))
+  } ensuring (_ => isPrefix(p ++ List(getSuffix(l, p).head), l))
 
+  @inlineOnce
+  @opaque
   def lemmaGetSuffixOnListWithItSelfIsEmpty[B](l: List[B]): Unit = {
+    decreases(l.size)
     lemmaIsPrefixRefl(l, l)
     l match {
       case Cons(hd, tl) => lemmaGetSuffixOnListWithItSelfIsEmpty(tl)
       case Nil()        => ()
     }
-  } ensuring (getSuffix(l, l).isEmpty)
+  } ensuring (_ => getSuffix(l, l).isEmpty)
 
+  @inlineOnce
+  @opaque
   def lemmaMoveElementToOtherListKeepsConcatEq[B](s1: List[B], hd2: B, tl2: List[B], tot: List[B]): Unit = {
     require(s1 ++ Cons(hd2, tl2) == tot)
 
@@ -293,8 +343,10 @@ object ListUtils {
       case Nil()          => ()
     }
 
-  } ensuring ((s1 ++ List(hd2)) ++ tl2 == tot)
+  } ensuring (_ => (s1 ++ List(hd2)) ++ tl2 == tot)
 
+  @inlineOnce
+  @opaque
   def lemmaPrefixFromSameListAndStrictlySmallerThenPrefixFromEachOther[B](s1: List[B], s2: List[B], l: List[B]): Unit = {
     require(isPrefix(s1, l))
     require(isPrefix(s2, l))
@@ -304,8 +356,10 @@ object ListUtils {
       case Cons(hd, tl) => lemmaPrefixFromSameListAndStrictlySmallerThenPrefixFromEachOther(s1.tail, tl, l.tail)
       case Nil()        =>
     }
-  } ensuring (isPrefix(s2, s1))
+  } ensuring (_ => isPrefix(s2, s1))
 
+  @inlineOnce
+  @opaque
   def concatWithoutDuplicates[B](baseList: List[B], newList: List[B]): List[B] = {
     require(ListOps.noDuplicate(baseList))
     newList match {
@@ -315,22 +369,30 @@ object ListUtils {
     }
   } ensuring (res => ListOps.noDuplicate(res) && (baseList ++ newList).content == res.content)
 
+  @inlineOnce
+  @opaque
   def removeDuplicates[B](list: List[B], acc: List[B] = Nil[B]()): List[B] = {
+    require(ListOps.noDuplicate(acc))
+    decreases(list.size)
     list match {
       case Cons(hd, tl) if acc.contains(hd) => removeDuplicates(tl, acc)
-      case Cons(hd, tl)                     => Cons(hd, removeDuplicates(tl, Cons(hd, acc)))
-      case Nil()                            => Nil[B]()
+      case Cons(hd, tl)                     => removeDuplicates(tl, Cons(hd, acc))
+      case Nil()                            => acc
     }
-  }
+  } ensuring (res => ListOps.noDuplicate(res) && res.content == (list ++ acc).content)
 
+  @inlineOnce
+  @opaque
   def lemmaSubseqRefl[B](l: List[B]): Unit = {
-
+    decreases(l.size)
     l match {
       case Nil()        => ()
       case Cons(hd, tl) => lemmaSubseqRefl(tl)
     }
-  } ensuring (ListSpecs.subseq(l, l))
+  } ensuring (_ => ListSpecs.subseq(l, l))
 
+  @inlineOnce
+  @opaque
   def lemmaTailIsSubseqOfList[B](elmt: B, l: List[B]): Unit = {
     l match {
       case Nil() => ()
@@ -341,8 +403,10 @@ object ListUtils {
       }
       case Cons(hd, tl) if hd != elmt => lemmaSubseqRefl(l)
     }
-  } ensuring (ListSpecs.subseq(l, Cons(elmt, l)))
+  } ensuring (_ => ListSpecs.subseq(l, Cons(elmt, l)))
 
+  @inlineOnce
+  @opaque
   def lemmaSubSeqTransitive[B](l1: List[B], l2: List[B], l3: List[B]): Unit = {
     require(ListSpecs.subseq(l1, l2))
     require(ListSpecs.subseq(l2, l3))
@@ -379,22 +443,28 @@ object ListUtils {
       case _ => ()
     }
 
-  } ensuring (ListSpecs.subseq(l1, l3))
+  } ensuring (_ => ListSpecs.subseq(l1, l3))
 
+  @inlineOnce
+  @opaque
   def lemmaConcatThenFirstSubseqOfTot[B](l1: List[B], l2: List[B]): Unit = {
     l1 match {
       case Cons(hd, tl) => lemmaConcatThenFirstSubseqOfTot(tl, l2)
       case Nil()        => ()
     }
-  } ensuring (ListSpecs.subseq(l1, l1 ++ l2))
+  } ensuring (_ => ListSpecs.subseq(l1, l1 ++ l2))
 
+  @inlineOnce
+  @opaque
   def lemmaConcatThenSecondSubseqOfTot[B](l1: List[B], l2: List[B]): Unit = {
     l1 match {
       case Cons(hd, tl) => lemmaConcatThenSecondSubseqOfTot(tl, l2)
       case Nil()        => lemmaSubseqRefl(l2)
     }
-  } ensuring (ListSpecs.subseq(l2, l1 ++ l2))
+  } ensuring (_ => ListSpecs.subseq(l2, l1 ++ l2))
 
+  @inlineOnce
+  @opaque
   def lemmaConcatTwoListsWhichNotContainThenTotNotContain[B](l1: List[B], l2: List[B], b: B): Unit = {
     require(!l1.contains(b))
     require(!l2.contains(b))
@@ -404,12 +474,58 @@ object ListUtils {
       case Cons(hd, tl)            => lemmaConcatTwoListsWhichNotContainThenTotNotContain(tl, l2, b)
       case Nil()                   => ()
     }
-  } ensuring (!(l1 ++ l2).contains(b))
+  } ensuring (_ => !(l1 ++ l2).contains(b))
 
+  @inlineOnce
+  @opaque
   def lemmaForallContainsThenForEqualLists[B](l1: List[B], l2: List[B], l1Bis: List[B], l2Bis: List[B]): Unit = {
     require(l1.forall(b => l2.contains(b)))
     require(l1 == l1Bis)
     require(l2 == l2Bis)
 
-  } ensuring (l1Bis.forall(b => l2Bis.contains(b)))
+  } ensuring (_ => l1Bis.forall(b => l2Bis.contains(b)))
+
+  @inlineOnce
+  @opaque
+  def lemmaForallContainsAndNoDuplicateThenSmallerList[B](l: List[B], lIn: List[B]): Unit = {
+    require(lIn.forall(e => l.contains(e)))
+    require(ListOps.noDuplicate(lIn))
+    decreases(lIn.size)
+
+    lIn match {
+      case Cons(hd, tl) => {
+
+        ListSpecs.forallContainsSubset(lIn, l)
+        assert(lIn.content.subsetOf(l.content))
+        assert(!tl.contains(hd))
+        val newList = l - hd
+        assert(newList.content == l.content - hd)
+        ListSpecs.subsetContains(tl, newList)
+        lemmaForallContainsAndNoDuplicateThenSmallerList(newList, tl)
+        assert(tl.size <= newList.size)
+        assert(tl.size + 1 == lIn.size)
+        assert(l.contains(hd))
+        assert(newList.content == l.content -- Set(hd))
+        lemmaRemoveElmtContainedSizeSmaller(l, hd)
+        assert(l.size > newList.size)
+      }
+      case Nil() => ()
+    }
+  } ensuring (_ => lIn.size <= l.size)
+
+  @inlineOnce
+  @opaque
+  def lemmaRemoveElmtContainedSizeSmaller[B](l: List[B], e: B): Unit = {
+    require(l.contains(e))
+    l match {
+      case Cons(hd, tl) if hd == e => {
+        assert(l - e == tl - e)
+        if (tl.contains(e)) {
+          lemmaRemoveElmtContainedSizeSmaller(tl, e)
+        }
+      }
+      case Cons(hd, tl) => lemmaRemoveElmtContainedSizeSmaller(tl, e)
+      case Nil()        => check(false)
+    }
+  } ensuring (_ => (l - e).size < l.size)
 }


### PR DESCRIPTION
Use `import stainless.lang.StaticChecks._` for better runtime performance.