### PR TITLE
Minor bug in the LongMap

### DIFF
--- a/WIP/SLOW/longmap/StrictlyOrderedLongListMap.scala
+++ b/WIP/SLOW/longmap/StrictlyOrderedLongListMap.scala
@@ -24,12 +24,12 @@ case class ListMapLongKey[B](toList: List[(Long, B)]) {
 
   @inline
   def size: Int = {
-    require(toList.size < Integer.MIN_VALUE)
+    require(toList.size < Integer.MAX_VALUE)
     TupleListOps.intSize(toList)
   }
 
   def nKeys: Int = {
-    require(toList.size < Integer.MIN_VALUE)
+    require(toList.size < Integer.MAX_VALUE)
     TupleListOps.intSizeKeys(TupleListOps.getKeysList(toList))
   }
 


### PR DESCRIPTION
While working on my smart home project, I realised that the `StrictlyOrderedLongMap` contains a bug. The bug is minor as it affects two functions that are never called but here is a fix.