### PR TITLE
Add BitStream example

### DIFF
--- a/WIP/bitstream/bitstream.scala
+++ b/WIP/bitstream/bitstream.scala
@@ -1,0 +1,563 @@
+import stainless.*
+import stainless.lang.{ghost => ghostExpr, *}
+import stainless.collection.*
+import stainless.annotation.*
+import stainless.proof.*
+import stainless.math.*
+import StaticChecks.*
+import utils.*
+
+object bitstream {
+  case class BitStream(
+    var buf: Array[Byte],
+    var currentByte: Int,
+    var currentBit: Int,
+  ) {
+    require(0 <= currentByte && currentByte <= buf.length)
+    require(0 <= currentBit && currentBit <= 7)
+    require(currentByte.toLong * 8 + currentBit.toLong <= 8 * buf.length.toLong)
+
+    def bitIndex: Long = {
+      currentByte.toLong * 8 + currentBit.toLong
+    }.ensuring(res => 0 <= res && res <= 8 * buf.length.toLong)
+
+    def moveOffset(diffInBits: Long): Unit = {
+      val res = bitIndex + diffInBits
+      require(0 <= res && res <= 8 * buf.length.toLong)
+      val nbBytes = (diffInBits / 8).toInt
+      val nbBits = (diffInBits % 8).toInt
+      currentByte += nbBytes
+      if (currentBit + nbBits < 0) {
+        currentByte -= 1
+        currentBit = 8 + nbBits + currentBit
+      } else if (currentBit + nbBits >= 8) {
+        currentBit = currentBit + nbBits - 8
+        currentByte += 1
+      } else {
+        currentBit += nbBits
+      }
+    }.ensuring(_ => old(this).bitIndex + diffInBits == bitIndex)
+  }
+
+  def isPrefix(b1: BitStream, b2: BitStream): Boolean = {
+    b1.buf.length <= b2.buf.length &&
+    b1.bitIndex <= b2.bitIndex &&
+    (b1.buf.length != 0) ==> arrayBitPrefix(b1.buf, b2.buf, 0, b1.bitIndex)
+  }
+
+  def isValidPair(w1: BitStream, w2: BitStream): Boolean = isPrefix(w1, w2)
+
+  @ghost
+  def reader(w1: BitStream, w2: BitStream): (BitStream, BitStream) = {
+    require(isValidPair(w1, w2))
+    val r1 = BitStream(snapshot(w2.buf), w1.currentByte, w1.currentBit)
+    val r2 = BitStream(snapshot(w2.buf), w2.currentByte, w2.currentBit)
+    (r1, r2)
+  }
+
+  @opaque @inlineOnce
+  def validTransitiveLemma(w1: BitStream, w2: BitStream, w3: BitStream): Unit = {
+    require(isValidPair(w1, w2))
+    require(isValidPair(w2, w3))
+    arrayPrefixTransitive(w1.buf, w2.buf, w3.buf, 0, w1.currentByte, w2.currentByte)
+    if (w1.currentByte < w1.buf.length) {
+      if (w1.currentByte < w2.currentByte) {
+        arrayPrefixImpliesEq(w2.buf, w3.buf, 0, w1.currentByte, w2.currentByte)
+        assert(w2.buf(w1.currentByte) == w3.buf(w1.currentByte))
+        check(bytePrefix(w1.buf(w1.currentByte), w3.buf(w1.currentByte), 0, w1.currentBit))
+      } else {
+        assert(w1.currentBit <= w2.currentBit)
+        check(bytePrefix(w1.buf(w1.currentByte), w3.buf(w1.currentByte), 0, w1.currentBit))
+      }
+    }
+    assert(((w1.currentByte < w1.buf.length) ==> bytePrefix(w1.buf(w1.currentByte), w3.buf(w1.currentByte), 0, w1.currentBit)))
+    check(isValidPair(w1, w3))
+  }.ensuring { _ =>
+    isValidPair(w1, w3)
+  }
+
+  ///////////////////////////////////////////////////////////////////
+
+  @opaque @inlineOnce
+  def BitStream_AppendBitOne(pBitStrm: BitStream): Unit = {
+    require(pBitStrm.bitIndex + 1 <= pBitStrm.buf.length.toLong * 8)
+    @ghost val oldpBitStrm = snapshot(pBitStrm)
+
+    val newB = (pBitStrm.buf(pBitStrm.currentByte) | masks(pBitStrm.currentBit)).toByte
+    pBitStrm.buf(pBitStrm.currentByte) = newB
+
+    ghostExpr {
+      arrayUpdatedAtPrefixLemma(oldpBitStrm.buf, pBitStrm.currentByte, newB)
+    }
+
+    if pBitStrm.currentBit < 7 then
+      pBitStrm.currentBit += 1
+    else
+      pBitStrm.currentBit = 0
+      pBitStrm.currentByte += 1
+
+  }.ensuring { _ =>
+    val w1 = old(pBitStrm)
+    val w2 = pBitStrm
+    w2.bitIndex == w1.bitIndex + 1 && isValidPair(w1, w2) && {
+      val (r1, r2) = reader(w1, w2)
+      val (r2Got, bitGot) = BitStream_ReadBitPure(r1)
+      bitGot == true && r2Got == r2
+    }
+  }
+
+  def BitStream_ReadBit(pBitStrm: BitStream): Boolean = {
+    require(pBitStrm.bitIndex + 1 <= pBitStrm.buf.length.toLong * 8)
+    val ret = (pBitStrm.buf(pBitStrm.currentByte) & masks(pBitStrm.currentBit)) != 0
+
+    if pBitStrm.currentBit < 7 then
+      pBitStrm.currentBit += 1
+    else
+      pBitStrm.currentBit = 0
+      pBitStrm.currentByte += 1
+
+    ret
+  }
+
+  @ghost @pure
+  def BitStream_ReadBitPure(pBitStrm: BitStream): (BitStream, Boolean) = {
+    require(pBitStrm.bitIndex + 1 <= pBitStrm.buf.length.toLong * 8)
+    val cpy = snapshot(pBitStrm)
+    val b = BitStream_ReadBit(cpy)
+    (cpy, b)
+  }
+
+  @ghost @opaque @inlineOnce
+  def readBitPrefixLemma(pBitStrm1: BitStream, pBitStrm2: BitStream): Unit = {
+    require(pBitStrm1.buf.length <= pBitStrm2.buf.length)
+    require(pBitStrm1.bitIndex + 7 < pBitStrm1.buf.length.toLong * 8)
+    require(pBitStrm1.bitIndex + 8 <= pBitStrm2.bitIndex)
+    require(arrayBitPrefix(
+      pBitStrm1.buf,
+      pBitStrm2.buf,
+      0,
+      pBitStrm1.bitIndex + 1
+    ))
+
+    val pBitStrm2Reset = BitStream(snapshot(pBitStrm2.buf), pBitStrm1.currentByte, pBitStrm1.currentBit)
+    val (pBitStrm1Res, b1) = BitStream_ReadBitPure(pBitStrm1)
+    val (pBitStrm2Res, b2) = BitStream_ReadBitPure(pBitStrm2Reset)
+
+    {
+      if (pBitStrm1.currentBit == 7) {
+        val end = (pBitStrm1.bitIndex / 8 + 1).toInt
+        arrayPrefixImpliesEq(pBitStrm1.buf, pBitStrm2.buf, 0, pBitStrm1.currentByte, end)
+      }
+    }.ensuring { _ =>
+      pBitStrm1Res.bitIndex == pBitStrm2Res.bitIndex && b1 == b2
+    }
+  }
+
+  def BitStream_BitStream_AppendBitOneLemma(pBitStrm: BitStream): Boolean = {
+    require(pBitStrm.bitIndex + 1 <= pBitStrm.buf.length.toLong * 8)
+    BitStream_AppendBitOne(pBitStrm)
+    val endPosition = pBitStrm.bitIndex
+    // Rewind
+    pBitStrm.moveOffset(-1)
+    val read = BitStream_ReadBit(pBitStrm)
+    read == true && pBitStrm.bitIndex == endPosition
+  }.holds
+
+  ///////////////////////////////////////////////////////////////////
+
+  def BitStream_ReadByte(pBitStrm: BitStream): Byte = {
+    require(pBitStrm.bitIndex + 8 <= pBitStrm.buf.length.toLong * 8)
+    val cb = pBitStrm.currentBit.toByte
+    val ncb = (8 - cb).toByte
+    var v = (pBitStrm.buf(pBitStrm.currentByte) << cb).toByte
+    pBitStrm.currentByte += 1
+
+    if cb > 0 then
+      v = (v | (pBitStrm.buf(pBitStrm.currentByte) & 0xFF) >> ncb).toByte
+    v
+  }
+
+  @ghost @pure
+  def BitStream_ReadBytePure(pBitStrm: BitStream): (BitStream, Byte) = {
+    require(pBitStrm.bitIndex + 8 <= pBitStrm.buf.length.toLong * 8)
+    val cpy = snapshot(pBitStrm)
+    val b = BitStream_ReadByte(cpy)
+    (cpy, b)
+  }
+
+  @ghost @opaque @inlineOnce
+  def readBytePrefixLemma(pBitStrm1: BitStream, pBitStrm2: BitStream): Unit = {
+    require(pBitStrm1.buf.length <= pBitStrm2.buf.length)
+    require(pBitStrm1.bitIndex + 7 < pBitStrm1.buf.length.toLong * 8)
+    require(pBitStrm1.bitIndex + 8 <= pBitStrm2.bitIndex)
+    require(arrayBitPrefix(
+      pBitStrm1.buf,
+      pBitStrm2.buf,
+      0,
+      pBitStrm1.bitIndex + 8
+    ))
+
+    val pBitStrm2Reset = BitStream(snapshot(pBitStrm2.buf), pBitStrm1.currentByte, pBitStrm1.currentBit)
+    val (pBitStrm1Res, b1) = BitStream_ReadBytePure(pBitStrm1)
+    val (pBitStrm2Res, b2) = BitStream_ReadBytePure(pBitStrm2Reset)
+
+    {
+      val end = (pBitStrm1.bitIndex / 8 + 1).toInt
+      arrayPrefixImpliesEq(pBitStrm1.buf, pBitStrm2.buf, 0, pBitStrm1.currentByte, end)
+    }.ensuring { _ =>
+      pBitStrm1Res.bitIndex == pBitStrm2Res.bitIndex && b1 == b2
+    }
+  }
+
+  @opaque @inlineOnce
+  def BitStream_AppendByte(pBitStrm: BitStream, v: Byte): Unit = {
+    require(pBitStrm.bitIndex + 8 <= pBitStrm.buf.length.toLong * 8)
+    @ghost val oldpBitStrm = snapshot(pBitStrm)
+    val cb = pBitStrm.currentBit.toByte
+    val ncb = (8 - cb).toByte
+    var mask = (~masksb(ncb)).toByte
+
+    pBitStrm.buf(pBitStrm.currentByte) = (pBitStrm.buf(pBitStrm.currentByte) & mask).toByte
+    pBitStrm.buf(pBitStrm.currentByte) = (pBitStrm.buf(pBitStrm.currentByte) | ((v & 0xFF) >> cb)).toByte
+    pBitStrm.currentByte += 1
+
+    ghostExpr {
+      check(
+        (oldpBitStrm.currentByte < oldpBitStrm.buf.length) ==>
+          bytePrefix(
+            oldpBitStrm.buf(oldpBitStrm.currentByte),
+            pBitStrm.buf(oldpBitStrm.currentByte),
+            0, oldpBitStrm.currentBit))
+    }
+    @ghost val old2pBitStrm = snapshot(pBitStrm)
+
+    if cb > 0 then
+      mask = (~mask).toByte
+      pBitStrm.buf(pBitStrm.currentByte) = (pBitStrm.buf(pBitStrm.currentByte) & mask).toByte
+      pBitStrm.buf(pBitStrm.currentByte) = (pBitStrm.buf(pBitStrm.currentByte) | (v << ncb)).toByte
+
+    ghostExpr {
+      arrayUpdatedAtPrefixLemma(oldpBitStrm.buf, pBitStrm.currentByte - 1, pBitStrm.buf(pBitStrm.currentByte - 1))
+      assert(arrayPrefix(oldpBitStrm.buf, old2pBitStrm.buf, 0, pBitStrm.currentByte - 1))
+
+      if (cb > 0) {
+        arrayUpdatedAtPrefixLemma(oldpBitStrm.buf, pBitStrm.currentByte, pBitStrm.buf(pBitStrm.currentByte))
+        arrayUpdatedAtPrefixLemma(old2pBitStrm.buf, pBitStrm.currentByte, pBitStrm.buf(pBitStrm.currentByte))
+        arrayPrefixTransitive(
+          oldpBitStrm.buf,
+          old2pBitStrm.buf,
+          pBitStrm.buf,
+          0, pBitStrm.currentByte - 1, pBitStrm.currentByte
+        )
+        check(arrayPrefix(
+          oldpBitStrm.buf,
+          pBitStrm.buf,
+          0,
+          oldpBitStrm.currentByte
+        ))
+      } else {
+        check(arrayPrefix(
+          oldpBitStrm.buf,
+          pBitStrm.buf,
+          0,
+          oldpBitStrm.currentByte
+        ))
+      }
+    }
+  }.ensuring { _ =>
+    val w1 = old(pBitStrm)
+    val w2 = pBitStrm
+    w2.bitIndex == w1.bitIndex + 8 && isValidPair(w1, w2) && {
+      val (r1, r2) = reader(w1, w2)
+      val (r2Got, vGot) = BitStream_ReadBytePure(r1)
+      vGot == v && r2Got == r2
+    }
+  }
+
+  def BitStream_AppendByteInvertibilityLemma(pBitStrm: BitStream, b: Byte): Boolean = {
+    require(pBitStrm.bitIndex + 8 <= pBitStrm.buf.length.toLong * 8)
+    BitStream_AppendByte(pBitStrm, b)
+    val endPosition = pBitStrm.bitIndex
+    // Rewind
+    pBitStrm.moveOffset(-8)
+    val read = BitStream_ReadByte(pBitStrm)
+    read == b && pBitStrm.bitIndex == endPosition
+  }.holds
+
+  ///////////////////////////////////////////////////////////////////
+
+  def BitStream_DecodeInteger16(pBitStrm: BitStream): Short = {
+    require(pBitStrm.bitIndex + 16 <= pBitStrm.buf.length.toLong * 8)
+    val b1 = BitStream_ReadByte(pBitStrm)
+    val b2 = BitStream_ReadByte(pBitStrm)
+    ((((b1 << 8) & 0xFF00) | (b2 & 0xFF)) & 0xFFFF).toShort
+  }
+
+  @ghost @pure
+  def BitStream_DecodeInteger16Pure(pBitStrm: BitStream): (BitStream, Short) = {
+    require(pBitStrm.bitIndex + 16 <= pBitStrm.buf.length.toLong * 8)
+    val cpy = snapshot(pBitStrm)
+    val l = BitStream_DecodeInteger16(cpy)
+    (cpy, l)
+  }
+
+  @ghost @opaque @inlineOnce
+  def decodeInt16PrefixLemma(pBitStrm1: BitStream, pBitStrm2: BitStream): Unit = {
+    require(pBitStrm1.buf.length <= pBitStrm2.buf.length)
+    require(pBitStrm1.bitIndex + 16 <= pBitStrm1.buf.length.toLong * 8)
+    require(pBitStrm1.bitIndex + 16 <= pBitStrm2.bitIndex)
+    require(arrayBitPrefix(
+      pBitStrm1.buf,
+      pBitStrm2.buf,
+      0,
+      pBitStrm1.bitIndex + 16
+    ))
+
+    val pBitStrm2Reset = BitStream(snapshot(pBitStrm2.buf), pBitStrm1.currentByte, pBitStrm1.currentBit)
+    val (pBitStrm1Res, i1) = BitStream_DecodeInteger16Pure(pBitStrm1)
+    val (pBitStrm2Res, i2) = BitStream_DecodeInteger16Pure(pBitStrm2Reset)
+
+    {
+      val end = (pBitStrm1.bitIndex / 8 + 2).toInt
+      arrayPrefixImpliesEq(pBitStrm1.buf, pBitStrm2.buf, 0, pBitStrm1.currentByte, end)
+      arrayPrefixImpliesEq(pBitStrm1.buf, pBitStrm2.buf, 0, pBitStrm1.currentByte + 1, end)
+    }.ensuring { _ =>
+      pBitStrm1Res.bitIndex == pBitStrm2Res.bitIndex && i1 == i2
+    }
+  }
+
+  @opaque @inlineOnce
+  def BitStream_EncodeInteger16(pBitStrm: BitStream, i: Short): Unit = {
+    require(pBitStrm.bitIndex + 16 <= pBitStrm.buf.length.toLong * 8)
+
+    val v1 = (i >> 8).toByte
+    val v2 = i.toByte
+    @ghost val pBitStrm1 = snapshot(pBitStrm)
+    BitStream_AppendByte(pBitStrm, v1)
+    @ghost val pBitStrm2 = snapshot(pBitStrm)
+    BitStream_AppendByte(pBitStrm, v2)
+
+    ghostExpr {
+      // For isValidPair
+      validTransitiveLemma(pBitStrm1, pBitStrm2, pBitStrm)
+      // Reading back the first byte gives the same result whether we are reading from pBitStrm2 or the end result pBitStream
+      val pBitStrm2Reset = BitStream(snapshot(pBitStrm2.buf), pBitStrm1.currentByte, pBitStrm1.currentBit)
+      readBytePrefixLemma(pBitStrm2Reset, pBitStrm)
+    }
+  }.ensuring { _ =>
+    val w1 = old(pBitStrm)
+    val w3 = pBitStrm
+    w3.bitIndex == w1.bitIndex + 16 && isValidPair(w1, w3) && {
+      val (r1, r3) = reader(w1, w3)
+      val (r3Got, iGot) = BitStream_DecodeInteger16Pure(r1)
+      iGot == i && r3Got == r3
+    }
+  }
+
+  def BitStream_EncodeInteger16InvertibilityLemma(pBitStrm: BitStream, i: Short): Boolean = {
+    require(pBitStrm.bitIndex + 16 <= pBitStrm.buf.length.toLong * 8)
+    BitStream_EncodeInteger16(pBitStrm, i)
+    val endPosition = pBitStrm.bitIndex
+    // Rewind
+    pBitStrm.moveOffset(-16)
+    val read = BitStream_DecodeInteger16(pBitStrm)
+    read == i && pBitStrm.bitIndex == endPosition
+  }.holds
+
+  ///////////////////////////////////////////////////////////////////
+
+  def BitStream_DecodeInteger32(pBitStrm: BitStream): Int = {
+    require(pBitStrm.bitIndex + 32 <= pBitStrm.buf.length.toLong * 8)
+    val b1 = BitStream_ReadByte(pBitStrm)
+    val b2 = BitStream_ReadByte(pBitStrm)
+    val b3 = BitStream_ReadByte(pBitStrm)
+    val b4 = BitStream_ReadByte(pBitStrm)
+    (b1 << 24) | ((b2 << 16) & 0xFF0000) | ((b3 << 8) & 0xFF00) | (b4 & 0xFF)
+  }
+
+  @ghost @pure
+  def BitStream_DecodeInteger32Pure(pBitStrm: BitStream): (BitStream, Int) = {
+    require(pBitStrm.bitIndex + 32 <= pBitStrm.buf.length.toLong * 8)
+    val cpy = snapshot(pBitStrm)
+    val i = BitStream_DecodeInteger32(cpy)
+    (cpy, i)
+  }
+
+  @ghost @opaque @inlineOnce
+  def decodeInt32PrefixLemma(pBitStrm1: BitStream, pBitStrm2: BitStream): Unit = {
+    require(pBitStrm1.buf.length <= pBitStrm2.buf.length)
+    require(pBitStrm1.bitIndex + 32 <= pBitStrm1.buf.length.toLong * 8)
+    require(pBitStrm1.bitIndex + 32 <= pBitStrm2.bitIndex)
+    require(arrayBitPrefix(
+      pBitStrm1.buf,
+      pBitStrm2.buf,
+      0,
+      pBitStrm1.bitIndex + 32
+    ))
+    val pBitStrm2Reset = BitStream(snapshot(pBitStrm2.buf), pBitStrm1.currentByte, pBitStrm1.currentBit)
+    val (pBitStrm1Res, i1) = BitStream_DecodeInteger32Pure(pBitStrm1)
+    val (pBitStrm2Res, i2) = BitStream_DecodeInteger32Pure(pBitStrm2Reset)
+
+    {
+      val end = (pBitStrm1.bitIndex / 8 + 4).toInt
+      arrayPrefixImpliesEq(pBitStrm1.buf, pBitStrm2.buf, 0, pBitStrm1.currentByte, end)
+      arrayPrefixImpliesEq(pBitStrm1.buf, pBitStrm2.buf, 0, pBitStrm1.currentByte + 1, end)
+      arrayPrefixImpliesEq(pBitStrm1.buf, pBitStrm2.buf, 0, pBitStrm1.currentByte + 2, end)
+      arrayPrefixImpliesEq(pBitStrm1.buf, pBitStrm2.buf, 0, pBitStrm1.currentByte + 3, end)
+    }.ensuring { _ =>
+      pBitStrm1Res.bitIndex == pBitStrm2Res.bitIndex && i1 == i2
+    }
+  }
+
+  @opaque @inlineOnce
+  def BitStream_EncodeInteger32(pBitStrm: BitStream, i: Int): Unit = {
+    require(pBitStrm.bitIndex + 32 <= pBitStrm.buf.length.toLong * 8)
+    @ghost val pBitStrm1 = snapshot(pBitStrm)
+    val v1 = (i >> 24).toByte
+    BitStream_AppendByte(pBitStrm, v1)
+    @ghost val pBitStrm2 = snapshot(pBitStrm)
+
+    val v2 = (i >> 16).toByte
+    BitStream_AppendByte(pBitStrm, v2)
+    @ghost val pBitStrm3 = snapshot(pBitStrm)
+
+    val v3 = (i >> 8).toByte
+    BitStream_AppendByte(pBitStrm, v3)
+    @ghost val pBitStrm4 = snapshot(pBitStrm)
+
+    val v4 = i.toByte
+    BitStream_AppendByte(pBitStrm, v4)
+
+    ghostExpr {
+      // 1 to end is a prefix
+      validTransitiveLemma(pBitStrm1, pBitStrm2, pBitStrm3)
+      validTransitiveLemma(pBitStrm1, pBitStrm3, pBitStrm4)
+      validTransitiveLemma(pBitStrm1, pBitStrm4, pBitStrm)
+
+      // Do the same for 2 and 3, these are needed for readBytePrefixLemma
+      validTransitiveLemma(pBitStrm2, pBitStrm3, pBitStrm4)
+      validTransitiveLemma(pBitStrm2, pBitStrm4, pBitStrm)
+      validTransitiveLemma(pBitStrm3, pBitStrm4, pBitStrm)
+
+      // Reading back the first byte gives the same result whether we are reading from pBitStrm2 or the end result pBitStream
+      val pBitStrm2Reset = BitStream(snapshot(pBitStrm2.buf), pBitStrm1.currentByte, pBitStrm1.currentBit)
+      readBytePrefixLemma(pBitStrm2Reset, pBitStrm)
+      // Ditto for 2nd and 3rd byte
+      val pBitStrm3Reset = BitStream(snapshot(pBitStrm3.buf), pBitStrm2.currentByte, pBitStrm2.currentBit)
+      readBytePrefixLemma(pBitStrm3Reset, pBitStrm)
+      val pBitStrm4Reset = BitStream(snapshot(pBitStrm4.buf), pBitStrm3.currentByte, pBitStrm3.currentBit)
+      readBytePrefixLemma(pBitStrm4Reset, pBitStrm)
+      // 4th is trivial
+    }
+  }.ensuring { _ =>
+    val w1 = old(pBitStrm)
+    val w5 = pBitStrm
+    w5.bitIndex == w1.bitIndex + 32 && isValidPair(w1, w5) && {
+      val (r1, r5) = reader(w1, w5)
+      val (r5Got, iGot) = BitStream_DecodeInteger32Pure(r1)
+      iGot == i && r5Got == r5
+    }
+  }
+
+  def BitStream_EncodeInteger32InvertibilityLemma(pBitStrm: BitStream, i: Int): Boolean = {
+    require(pBitStrm.bitIndex + 32 <= pBitStrm.buf.length.toLong * 8)
+    BitStream_EncodeInteger32(pBitStrm, i)
+    val endPosition = pBitStrm.bitIndex
+    // Rewind
+    pBitStrm.moveOffset(-32)
+    val read = BitStream_DecodeInteger32(pBitStrm)
+    read == i && pBitStrm.bitIndex == endPosition
+  }.holds
+
+  ///////////////////////////////////////////////////////////////////
+
+  def BitStream_DecodeInteger64(pBitStrm: BitStream): Long = {
+    require(pBitStrm.bitIndex + 64 <= pBitStrm.buf.length.toLong * 8)
+    val i1 = BitStream_DecodeInteger32(pBitStrm)
+    val i2 = BitStream_DecodeInteger32(pBitStrm)
+    (i1.toLong << 32) | (i2.toLong & 0xFFFFFFFFL)
+  }
+
+  @ghost @pure
+  def BitStream_DecodeInteger64Pure(pBitStrm: BitStream): (BitStream, Long) = {
+    require(pBitStrm.bitIndex + 64 <= pBitStrm.buf.length.toLong * 8)
+    val cpy = snapshot(pBitStrm)
+    val l = BitStream_DecodeInteger64(cpy)
+    (cpy, l)
+  }
+
+  @ghost @opaque @inlineOnce
+  def decodeInt64PrefixLemma(pBitStrm1: BitStream, pBitStrm2: BitStream): Unit = {
+    require(pBitStrm1.buf.length <= pBitStrm2.buf.length)
+    require(pBitStrm1.bitIndex + 64 <= pBitStrm1.buf.length.toLong * 8)
+    require(pBitStrm1.bitIndex + 64 <= pBitStrm2.bitIndex)
+    require(arrayBitPrefix(
+      pBitStrm1.buf,
+      pBitStrm2.buf,
+      0,
+      pBitStrm1.bitIndex + 64
+    ))
+
+    val pBitStrm2Reset = BitStream(snapshot(pBitStrm2.buf), pBitStrm1.currentByte, pBitStrm1.currentBit)
+    val (pBitStrm1Res, i1) = BitStream_DecodeInteger64Pure(pBitStrm1)
+    val (pBitStrm2Res, i2) = BitStream_DecodeInteger64Pure(pBitStrm2Reset)
+
+    {
+      arrayBitPrefixSlicedLemma(pBitStrm1.buf, pBitStrm2.buf, 0, pBitStrm1.bitIndex + 64, 0, pBitStrm1.bitIndex + 32)
+      decodeInt32PrefixLemma(pBitStrm1, BitStream(snapshot(pBitStrm2.buf), pBitStrm1.currentByte + 4, pBitStrm1.currentBit))
+      val (pBitStrm1_2, hi1) = BitStream_DecodeInteger32Pure(pBitStrm1)
+      val (pBitStrm2_2, hi2) = BitStream_DecodeInteger32Pure(pBitStrm2Reset)
+      assert(hi1 == hi2)
+      decodeInt32PrefixLemma(pBitStrm1_2, BitStream(snapshot(pBitStrm2_2.buf), pBitStrm1_2.currentByte + 4, pBitStrm1_2.currentBit))
+      val (_, lo1) = BitStream_DecodeInteger32Pure(pBitStrm1_2)
+      val (_, lo2) = BitStream_DecodeInteger32Pure(pBitStrm2_2)
+      assert(lo1 == lo2)
+    }.ensuring { _ =>
+      pBitStrm1Res.bitIndex == pBitStrm2Res.bitIndex && i1 == i2
+    }
+  }
+
+  @opaque @inlineOnce
+  def BitStream_EncodeInteger64(pBitStrm: BitStream, i: Long): Unit = {
+    require(pBitStrm.bitIndex + 64 <= pBitStrm.buf.length.toLong * 8)
+
+    @ghost val pBitStrm1 = snapshot(pBitStrm)
+    val v1 = (i >> 32).toInt
+    BitStream_EncodeInteger32(pBitStrm, v1)
+    @ghost val pBitStrm2 = snapshot(pBitStrm)
+
+    val v2 = i.toInt
+    BitStream_EncodeInteger32(pBitStrm, v2)
+
+    ghostExpr {
+      validTransitiveLemma(pBitStrm1, pBitStrm2, pBitStrm)
+      val pBitStrm2Reset = BitStream(snapshot(pBitStrm2.buf), pBitStrm1.currentByte, pBitStrm1.currentBit)
+      decodeInt32PrefixLemma(pBitStrm2Reset, pBitStrm)
+    }
+  }.ensuring { _ =>
+    val w1 = old(pBitStrm)
+    val w3 = pBitStrm
+    w3.bitIndex == w1.bitIndex + 64 && isValidPair(w1, w3) && {
+      val (r1, r3) = reader(w1, w3)
+      val (r3Got, iGot) = BitStream_DecodeInteger64Pure(r1)
+      iGot == i && r3Got == r3
+    }
+  }
+
+
+  def BitStream_EncodeInteger64InvertibilityLemma(pBitStrm: BitStream, i: Long): Boolean = {
+    // For all streams with enough buffer space, and all long
+    require(pBitStrm.bitIndex + 64 <= pBitStrm.buf.length.toLong * 8)
+    // 1. encoding
+    BitStream_EncodeInteger64(pBitStrm, i)
+    val endPosition = pBitStrm.bitIndex
+    // 2. rewinding
+    pBitStrm.moveOffset(-64)
+    // 3. reading back
+    val read = BitStream_DecodeInteger64(pBitStrm)
+    // 4.
+    //   a. gives the same long
+    //   b. advances the BitStream by 64 bits
+    read == i && pBitStrm.bitIndex == endPosition
+  }.holds
+}

--- a/WIP/bitstream/stainless.conf
+++ b/WIP/bitstream/stainless.conf
@@ -1,0 +1,4 @@
+timeout = 20
+batched = true
+strict-arithmetic = false
+solvers = "smt-cvc4,smt-z3,no-inc:smt-z3:z3 tactic.default_tactic=smt sat.euf=true"

--- a/WIP/bitstream/utils.scala
+++ b/WIP/bitstream/utils.scala
@@ -1,0 +1,270 @@
+import stainless.*
+import stainless.lang.*
+import stainless.collection.*
+import stainless.annotation.{wrapping => _, *}
+import stainless.proof.*
+import stainless.math.*
+import StaticChecks.*
+
+object utils {
+  val masks: Array[Byte] = Array(
+    -0x80, // -128 / 1000 0000 / x80
+    0x40,  //   64 / 0100 0000 / x40
+    0x20,  //   32 / 0010 0000 / x20
+    0x10,  //   16 / 0001 0000 / x10
+    0x08,  //    8 / 0000 1000 / x08
+    0x04,  //    4 / 0000 0100 / x04
+    0x02,  //    2 / 0000 0010 / x02
+    0x01,  //    1 / 0000 0001 / x01
+  )
+  val masksb: Array[Byte] = Array(
+    0x00, //   0 / 0000 0000 / x00
+    0x01, //   1 / 0000 0001 / x01
+    0x03, //   3 / 0000 0011 / x03
+    0x07, //   7 / 0000 0111 / x07
+    0x0F, //  15 / 0000 1111 / x0F
+    0x1F, //  31 / 0001 1111 / x1F
+    0x3F, //  63 / 0011 1111 / x3F
+    0x7F, // 127 / 0111 1111 / x7F
+    -0x1, //  -1 / 1111 1111 / xFF
+  )
+
+  val masksc: Array[Byte] = Array(
+     0x00,  //  / 0000 0000 /
+    -0x80,  //  / 1000 0000 /
+    -0x40,  //  / 1100 0000 /
+    -0x20,  //  / 1110 0000 /
+    -0x10,  //  / 1111 0000 /
+    -0x08,  //  / 1111 1000 /
+    -0x04,  //  / 1111 1100 /
+    -0x02,  //  / 1111 1110 /
+  )
+  val masks2: Array[Int] = Array(
+    0x00000000, //         0 / 0000 0000 0000 0000 0000 0000 0000 0000 / 0x00000000
+    0x000000FF, //       255 / 0000 0000 0000 0000 0000 0000 1111 1111 / 0x000000FF
+    0x0000FF00, //     65280 / 0000 0000 0000 0000 1111 1111 0000 0000 / 0x0000FF00
+    0x00FF0000, //  16711680 / 0000 0000 1111 1111 0000 0000 0000 0000 / 0x00FF0000
+    0xFF000000, // -16777216 / 1111 1111 0000 0000 0000 0000 0000 0000 / 0xFF000000
+  )
+
+  def arrayPrefix[T](a1: Array[T], a2: Array[T], from: Int, to: Int): Boolean = {
+    require(0 <= from && from <= to)
+    require(a1.length <= a2.length)
+    require(to <= a1.length)
+    decreases(to - from)
+    if (from == to) true
+    else a1(from) == a2(from) && arrayPrefix(a1, a2, from + 1, to)
+  }
+
+  @opaque @inlineOnce
+  def arrayPrefixSlicedLemma[T](a1: Array[T], a2: Array[T], from: Int, to: Int, fromSlice: Int, toSlice: Int): Unit = {
+    require(0 <= from && from <= to)
+    require(a1.length <= a2.length)
+    require(to <= a1.length)
+    require(from <= fromSlice && fromSlice <= toSlice && toSlice <= to)
+    require(arrayPrefix(a1, a2, from, to))
+
+    @opaque @inlineOnce
+    def rec(i: Int): Unit = {
+      require(fromSlice <= i && i <= to)
+      require(arrayPrefix(a1, a2, i, to)) // the original predicate we are unfolding
+      require((i <= toSlice) ==> arrayPrefix(a1, a2, i, toSlice)) // the resulting predicate we are folding
+      decreases(i)
+      if (i == fromSlice) ()
+      else {
+        arrayPrefixImpliesEq(a1, a2, from, i - 1, to)
+        rec(i - 1)
+      }
+    }.ensuring(_ => arrayPrefix(a1, a2, fromSlice, toSlice))
+
+    rec(to)
+  }.ensuring(_ => arrayPrefix(a1, a2, fromSlice, toSlice))
+
+  @opaque @inlineOnce
+  def arrayPrefixAppend[T](a1: Array[T], a2: Array[T], from: Int, to: Int) = {
+    require(0 <= from && from <= to)
+    require(a1.length <= a2.length)
+    require(to < a1.length)
+    require(arrayPrefix(a1, a2, from, to))
+    require(a1(to) == a2(to))
+
+    @opaque @inlineOnce
+    def rec(i: Int): Unit = {
+      require(from <= i && i <= to)
+      require(arrayPrefix(a1, a2, i, to + 1))
+      decreases(i)
+      if (i == from) ()
+      else {
+        arrayPrefixImpliesEq(a1, a2, from, i - 1, to)
+        rec(i - 1)
+      }
+    }.ensuring { _ =>
+      arrayPrefix(a1, a2, from, to + 1)
+    }
+    rec(to)
+  }.ensuring(_ => arrayPrefix(a1, a2, from, to + 1))
+
+  @opaque @inlineOnce
+  def arrayPrefixTransitive[T](a1: Array[T], a2: Array[T], a3: Array[T], from: Int, mid: Int, to: Int): Unit = {
+    require(0 <= from && from <= mid && mid <= to)
+    require(a1.length <= a2.length && a2.length <= a3.length)
+    require(mid <= a1.length && to <= a2.length)
+    require(arrayPrefix(a1, a2, from, mid))
+    require(arrayPrefix(a2, a3, from, to))
+
+    @opaque @inlineOnce
+    def rec(i: Int): Unit = {
+      require(from <= i && i <= mid)
+      require(arrayPrefix(a1, a2, i, mid))
+      require(arrayPrefix(a2, a3, i, to))
+      require(arrayPrefix(a1, a3, from, i))
+      decreases(to - i)
+      if (i == mid) ()
+      else {
+        arrayPrefixAppend(a1, a3, from, i)
+        rec(i + 1)
+      }
+    }.ensuring { _ =>
+      arrayPrefix(a1, a3, from, mid)
+    }
+    rec(from)
+  }.ensuring(_ => arrayPrefix(a1, a3, from, mid))
+
+  @opaque @inlineOnce
+  def arrayUpdatedAtPrefixLemma[T](a: Array[T], at: Int, v: T): Unit = {
+    require(0 <= at && at < a.length)
+
+    @opaque @inlineOnce
+    def rec(i: Int): Unit = {
+      require(0 <= i && i <= at)
+      require(arrayPrefix(a, freshCopy(a).updated(at, v), i, at))
+      decreases(i)
+      if (i == 0) ()
+      else rec(i - 1)
+    }.ensuring { _ =>
+      arrayPrefix(a, freshCopy(a).updated(at, v), 0, at)
+    }
+
+    rec(at)
+  }.ensuring { _ =>
+    arrayPrefix(a, freshCopy(a).updated(at, v), 0, at)
+  }
+
+  @opaque @inlineOnce
+  def arrayPrefixImpliesEq[T](a1: Array[T], a2: Array[T], from: Int, at: Int, to: Int): Unit = {
+    require(0 <= from && from <= to)
+    require(a1.length <= a2.length)
+    require(to <= a1.length)
+    require(from <= at && at < to)
+    require(arrayPrefix(a1, a2, from, to))
+
+    @opaque @inlineOnce
+    def rec(i: Int): Unit = {
+      require(from <= i && i <= at)
+      require(arrayPrefix(a1, a2, i, to))
+      decreases(to - i)
+      if (i == at) ()
+      else rec(i + 1)
+    }.ensuring { _ =>
+      a1(at) == a2(at)
+    }
+    rec(from)
+  }.ensuring(_ => a1(at) == a2(at))
+
+  def arrayPrefixRev[T](a1: Array[T], a2: Array[T], from: Int, to: Int): Boolean = {
+    require(0 <= from && from <= to)
+    require(a1.length <= a2.length)
+    require(to <= a1.length)
+    decreases(to - from)
+    if (from == to) true
+    else a1(to - 1) == a2(to - 1) && arrayPrefixRev(a1, a2, from, to - 1)
+  }
+
+  def arrayBitIndices(fromBit: Long, toBit: Long): (Int, Int, Int, Int) = {
+    require(0 <= fromBit && fromBit <= toBit && toBit <= 8 * Int.MaxValue.toLong)
+    val arrPrefixStart = (fromBit / 8 + (if (fromBit % 8 == 0) 0 else 1)).toInt
+    val arrPrefixEnd = (toBit / 8).toInt
+    val fromBitIx = (fromBit / 8).toInt
+    val toBitIx = (toBit / 8).toInt
+    (arrPrefixStart, arrPrefixEnd, fromBitIx, toBitIx)
+  }
+
+  def arrayBitPrefix(a1: Array[Byte], a2: Array[Byte], fromBit: Long, toBit: Long): Boolean = {
+    require(a1.length <= a2.length)
+    require(0 <= fromBit && fromBit <= toBit && toBit <= a1.length.toLong * 8)
+    require(fromBit < a1.length.toLong * 8)
+    (fromBit < toBit) ==> {
+      val (arrPrefixStart, arrPrefixEnd, fromBitIx, toBitIx) = arrayBitIndices(fromBit, toBit)
+      val restFrom = (fromBit % 8).toInt
+      val restTo = (toBit % 8).toInt
+      ((arrPrefixStart < arrPrefixEnd) ==> arrayPrefix(a1, a2, arrPrefixStart, arrPrefixEnd)) && {
+        if (fromBitIx == toBitIx) {
+          bytePrefix(a1(fromBitIx), a2(fromBitIx), restFrom, restTo)
+        } else {
+          bytePrefix(a1(fromBitIx), a2(fromBitIx), restFrom, 7) &&
+          ((restTo != 0) ==> bytePrefix(a1(toBitIx), a2(toBitIx), 0, restTo))
+        }
+      }
+    }
+  }
+
+  @opaque @inlineOnce
+  def arrayBitPrefixSlicedLemma(a1: Array[Byte], a2: Array[Byte], fromBit: Long, toBit: Long, fromSlice: Long, toSlice: Long): Unit = {
+    require(a1.length <= a2.length)
+    require(0 <= fromBit && fromBit <= toBit && toBit <= a1.length.toLong * 8)
+    require(fromBit < a1.length.toLong * 8)
+    require(arrayBitPrefix(a1, a2, fromBit, toBit))
+    require(fromBit <= fromSlice && fromSlice <= toSlice && toSlice <= toBit)
+    require(fromSlice < a1.length.toLong * 8)
+
+    if (fromSlice == toSlice) ()
+    else {
+      val (arrPrefixStart, arrPrefixEnd, fromBitIx, toBitIx) = arrayBitIndices(fromBit, toBit)
+      val restFrom = (fromBit % 8).toInt
+      val restTo = (toBit % 8).toInt
+
+      val (arrPrefixSliceStart, arrPrefixSliceEnd, fromSliceIx, toSliceIx) = arrayBitIndices(fromSlice, toSlice)
+      val restFromSlice = (fromSlice % 8).toInt
+      val restToSlice = (toSlice % 8).toInt
+
+      if (arrPrefixSliceStart < arrPrefixSliceEnd) {
+        arrayPrefixSlicedLemma(a1, a2, arrPrefixStart, arrPrefixEnd, arrPrefixSliceStart, arrPrefixSliceEnd)
+      }
+      assert {
+        if (fromBitIx == toBitIx) {
+          bytePrefix(a1(fromBitIx), a2(fromBitIx), restFrom, restTo)
+        } else {
+          bytePrefix(a1(fromBitIx), a2(fromBitIx), restFrom, 7) &&
+          ((restTo != 0) ==> bytePrefix(a1(toBitIx), a2(toBitIx), 0, restTo))
+        }
+      }
+
+      if (fromBitIx < fromSliceIx && fromSliceIx < toBitIx) {
+        arrayPrefixImpliesEq(a1, a2, arrPrefixStart, fromSliceIx, arrPrefixEnd)
+      }
+      if (toSliceIx < toBitIx && fromBitIx < toSliceIx) {
+        arrayPrefixImpliesEq(a1, a2, arrPrefixStart, toSliceIx, arrPrefixEnd)
+      }
+
+      if (fromSliceIx == toSliceIx) {
+        assert(bytePrefix(a1(fromSliceIx), a2(fromSliceIx), restFromSlice, restToSlice))
+      } else {
+        assert(bytePrefix(a1(fromSliceIx), a2(fromSliceIx), restFromSlice, 7))
+        assert(((restToSlice != 0) ==> bytePrefix(a1(toSliceIx), a2(toSliceIx), 0, restToSlice)))
+      }
+    }
+  }.ensuring(_ => arrayBitPrefix(a1, a2, fromSlice, toSlice))
+
+  def bytePrefix(b1: Byte, b2: Byte, from: Int, to: Int): Boolean = {
+    require(0 <= from && from <= to && to <= 7)
+    ((b1 & masksc(to) & masksb(8 - from)) & 0xFF) == ((b2 & masksc(to) & masksb(8 - from)) & 0xFF)
+  }
+
+  @opaque @inlineOnce
+  def bytePrefixTransitive(b1: Byte, b2: Byte, b3: Byte, mid: Int, to: Int): Unit = {
+    require(0 <= mid && mid <= to && to <= 7)
+    require(bytePrefix(b1, b2, 0, mid))
+    require(bytePrefix(b2, b3, 0, to))
+
+  }.ensuring(_ => bytePrefix(b1, b3, 0, mid))
+}


### PR DESCRIPTION
This is a verified sample adapted from https://github.com/ateleris/asn1scc/tree/scala-backend/asn1scala/src/main/scala/asn1scala
Note that the writing/reading of 16, 32 and 64 bits integer is done differently to show how to build using "primitive bricks" (here, using `BitStream_AppendByte`/`BitStream_ReadByte`) 