### PR TITLE
Add measures for lexers/regex

### DIFF
--- a/lexers/regex/ListUtils.scala
+++ b/lexers/regex/ListUtils.scala
@@ -27,9 +27,12 @@ object ListUtils {
     res
   } ensuring (res => res ++ List(l.last) == l)
 
-  def reverseList[B](l: List[B]): List[B] = l match {
-    case Cons(hd, tl) => reverseList(tl) ++ List(hd)
-    case Nil()        => Nil()
+  def reverseList[B](l: List[B]): List[B] = {
+    decreases(l)
+    l match {
+      case Cons(hd, tl) => reverseList(tl) ++ List(hd)
+      case Nil()        => Nil()
+    }
   }
 
   def getSuffix[B](l: List[B], p: List[B]): List[B] = {
@@ -43,6 +46,7 @@ object ListUtils {
 
   def getIndex[B](l: List[B], e: B): BigInt = {
     require(l.contains(e))
+    decreases(l)
     l match {
       case Cons(hd, tl) if hd == e => BigInt(0)
       case Cons(hd, tl) if hd != e => 1 + getIndex(tl, e)
@@ -69,6 +73,7 @@ object ListUtils {
   @opaque
   def lemmaConsecutiveSubseqThenSubseq[B](l1: List[B], l2: List[B]): Unit = {
     require(consecutiveSubseq(l1, l2))
+    decreases(l2)
     (l1, l2) match {
       case (Cons(hd1, tl1), Cons(hd2, tl2)) if consecutiveSubseqAtHead(l1, l2) => lemmaConsecutiveSubseqThenSubseq(tl1, tl2)
       case (Cons(hd1, tl1), Cons(hd2, tl2))                                    => lemmaConsecutiveSubseqThenSubseq(l1, tl2)
@@ -116,6 +121,7 @@ object ListUtils {
     require(l.contains(e1))
     require(l.contains(e2))
     require(getIndex(l, e1) == getIndex(l, e2))
+    decreases(l)
 
     if (getIndex(l, e1) == 0) {
       assert(l.head == e1)
@@ -173,6 +179,7 @@ object ListUtils {
     require(p1 ++ s1 == l)
     require(!s1.isEmpty)
     require(p1.size < p2.size)
+    decreases(p1)
 
     lemmaConcatTwoListThenFirstIsPrefix(p1, s1)
 
@@ -186,6 +193,7 @@ object ListUtils {
   @opaque
   def lemmaConcatAssociativity[B](l1: List[B], elmt: B, l2: List[B], tot: List[B]): Unit = {
     require((l1 ++ List(elmt)) ++ l2 == tot)
+    decreases(l1)
     assert(l1 ++ List(elmt) ++ l2 == tot)
     l1 match {
       case Cons(hd, tl) => lemmaConcatAssociativity(tl, elmt, l2, tot.tail)
@@ -200,6 +208,7 @@ object ListUtils {
       l2: List[B],
       l3: List[B]
   ): Unit = {
+    decreases(l1)
     l1 match {
       case Cons(hd, tl) => {
         lemmaTwoListsConcatAssociativity(tl, l2, l3)
@@ -213,6 +222,7 @@ object ListUtils {
   @opaque
   def lemmaRemoveLastConcatenatedPrefixStillPrefix[B](l: List[B], elmt: B, tot: List[B]): Unit = {
     require(isPrefix(l ++ List(elmt), tot))
+    decreases(l)
     l match {
       case Cons(hd, tl) => lemmaRemoveLastConcatenatedPrefixStillPrefix(tl, elmt, tot.tail)
       case Nil()        => ()
@@ -225,6 +235,7 @@ object ListUtils {
     require(!l.isEmpty)
     require(isPrefix(p, l))
     require(p.size < l.size)
+    decreases(p)
     p match {
       case Cons(hd, tl) => lemmaRemoveLastPrefixStillPrefix(tl, l.tail)
       case Nil()        => ()
@@ -267,6 +278,7 @@ object ListUtils {
   def lemmaRemoveLastFromBothSidePreservesEq[B](p: List[B], s: List[B], l: List[B]): Unit = {
     require(p ++ s == l)
     require(!s.isEmpty)
+    decreases(p)
     p match {
       case Cons(hd, tl) => lemmaRemoveLastFromBothSidePreservesEq(tl, s, l.tail)
       case Nil()        => ()
@@ -351,6 +363,7 @@ object ListUtils {
     require(isPrefix(s1, l))
     require(isPrefix(s2, l))
     require(s2.size <= s1.size)
+    decreases(s2)
 
     s2 match {
       case Cons(hd, tl) => lemmaPrefixFromSameListAndStrictlySmallerThenPrefixFromEachOther(s1.tail, tl, l.tail)
@@ -362,6 +375,7 @@ object ListUtils {
   @opaque
   def concatWithoutDuplicates[B](baseList: List[B], newList: List[B]): List[B] = {
     require(ListOps.noDuplicate(baseList))
+    decreases(newList)
     newList match {
       case Cons(hd, tl) if baseList.contains(hd)  => concatWithoutDuplicates(baseList, tl)
       case Cons(hd, tl) if !baseList.contains(hd) => concatWithoutDuplicates(Cons(hd, baseList), tl)
@@ -448,6 +462,7 @@ object ListUtils {
   @inlineOnce
   @opaque
   def lemmaConcatThenFirstSubseqOfTot[B](l1: List[B], l2: List[B]): Unit = {
+    decreases(l1)
     l1 match {
       case Cons(hd, tl) => lemmaConcatThenFirstSubseqOfTot(tl, l2)
       case Nil()        => ()
@@ -457,6 +472,7 @@ object ListUtils {
   @inlineOnce
   @opaque
   def lemmaConcatThenSecondSubseqOfTot[B](l1: List[B], l2: List[B]): Unit = {
+    decreases(l1)
     l1 match {
       case Cons(hd, tl) => lemmaConcatThenSecondSubseqOfTot(tl, l2)
       case Nil()        => lemmaSubseqRefl(l2)
@@ -517,6 +533,7 @@ object ListUtils {
   @opaque
   def lemmaRemoveElmtContainedSizeSmaller[B](l: List[B], e: B): Unit = {
     require(l.contains(e))
+    decreases(l)
     l match {
       case Cons(hd, tl) if hd == e => {
         assert(l - e == tl - e)

--- a/lexers/regex/VerifiedLexer.scala
+++ b/lexers/regex/VerifiedLexer.scala
@@ -84,9 +84,12 @@ object VerifiedLexer {
     def ruleValid[C](r: Rule[C]): Boolean = {
       validRegex(r.regex) && !nullable(r.regex) && r.tag != ""
     }
-    def noDuplicateTag[C](rules: List[Rule[C]], acc: List[String] = Nil()): Boolean = rules match {
-      case Nil()        => true
-      case Cons(hd, tl) => !acc.contains(hd.tag) && noDuplicateTag(tl, Cons(hd.tag, acc))
+    def noDuplicateTag[C](rules: List[Rule[C]], acc: List[String] = Nil()): Boolean = {
+      decreases(rules)
+      rules match {
+        case Nil()        => true
+        case Cons(hd, tl) => !acc.contains(hd.tag) && noDuplicateTag(tl, Cons(hd.tag, acc))
+      }
     }
     def rulesValid[C](rs: List[Rule[C]]): Boolean = {
       rs match {
@@ -119,6 +122,7 @@ object VerifiedLexer {
     }
 
     def ruleDisjointCharsFromAllFromOtherType[C](r: Rule[C], rules: List[Rule[C]]): Boolean = {
+      decreases(rules)
       rules match {
         case Cons(hd, tl) if hd.isSeparator != r.isSeparator => rulesUseDisjointChars(r, hd) && ruleDisjointCharsFromAllFromOtherType(r, tl)
         case Cons(hd, tl)                                    => ruleDisjointCharsFromAllFromOtherType(r, tl)
@@ -170,6 +174,7 @@ object VerifiedLexer {
       * @param l
       */
     def print[C](l: List[Token[C]]): List[C] = {
+      decreases(l)
       l match {
         case Cons(hd, tl) => hd.characters ++ print(tl)
         case Nil()        => Nil[C]()
@@ -183,6 +188,7 @@ object VerifiedLexer {
       */
     def printWithSeparatorToken[C](l: List[Token[C]], separatorToken: Token[C]): List[C] = {
       require(separatorToken.isSeparator)
+      decreases(l)
       l match {
         case Cons(hd, tl) => hd.characters ++ separatorToken.characters ++ printWithSeparatorToken(tl, separatorToken)
         case Nil()        => Nil[C]()
@@ -203,6 +209,7 @@ object VerifiedLexer {
       require(separatorToken.isSeparator)
       require(l.forall(!_.isSeparator))
       require(sepAndNonSepRulesDisjointChars(rules, rules))
+      decreases(l)
 
       l match {
         case Cons(hd, tl) => {
@@ -376,6 +383,7 @@ object VerifiedLexer {
         getRuleFromTag(rules, separatorToken.tag).get.isSeparator
       })
       require(sepAndNonSepRulesDisjointChars(rules, rules))
+      decreases(tokens)
 
       tokens match {
         case Cons(hd, tl) => {
@@ -808,6 +816,7 @@ object VerifiedLexer {
       require(rulesInvariant(rules))
       require(!rules.isEmpty)
       require(maxPrefix(rules, input).isDefined && maxPrefix(rules, input).get._1 == token)
+      decreases(rules)
 
       rules match {
         case Cons(hd, tl) => {
@@ -885,6 +894,7 @@ object VerifiedLexer {
       require(ListUtils.getIndex(rules, rBis) < ListUtils.getIndex(rules, r))
       require(ruleValid(r))
       require(matchR(r.regex, p))
+      decreases(rules)
 
       assert(ListUtils.getIndex(rules, rBis) < ListUtils.getIndex(rules, r))
 
@@ -1136,6 +1146,7 @@ object VerifiedLexer {
     def lemmaNoDuplTagThenTailRulesCannotProduceHeadTagInTok[C](rHead: Rule[C], rTail: List[Rule[C]], input: List[C]): Unit = {
       require(!rTail.isEmpty)
       require(rulesInvariant(Cons(rHead, rTail)))
+      decreases(rTail)
 
       rTail match {
         case Cons(hd, tl) => {
@@ -1220,6 +1231,7 @@ object VerifiedLexer {
       require(rules.contains(r))
 
       require(maxPrefix(rules, input).isEmpty)
+      decreases(rules)
 
       lemmaRuleInListAndRulesValidThenRuleIsValid(r, rules)
 
@@ -1314,6 +1326,7 @@ object VerifiedLexer {
     def lemmaNoDuplicateSameWithAccWithSameContent[C](l: List[Rule[C]], acc: List[String], newAcc: List[String]): Unit = {
       require(noDuplicateTag(l, acc))
       require(acc.content == newAcc.content)
+      decreases(l)
 
       l match {
         case Cons(hd, tl) => {
@@ -1354,6 +1367,7 @@ object VerifiedLexer {
       require(rules.contains(r2))
       require(noDuplicateTag(rules))
       require(ListUtils.getIndex(rules, r1) < ListUtils.getIndex(rules, r2))
+      decreases(rules)
 
       if (rules.head == r1) {
         lemmaNoDuplicateAndTagInAccThenRuleCannotHaveSame(rules.tail, r2, r1.tag, List(r1.tag))
@@ -1409,6 +1423,7 @@ object VerifiedLexer {
       require(!rNSep.isSeparator)
       require(rSep.isSeparator)
       require(ruleDisjointCharsFromAllFromOtherType(rNSep, rules))
+      decreases(rules)
 
       rules match {
         case Cons(hd, tl) if hd == rSep =>
@@ -1454,6 +1469,7 @@ object VerifiedLexer {
       require(!rNSep.isSeparator)
       require(rSep.isSeparator)
       require(ruleDisjointCharsFromAllFromOtherType(rNSep, rules))
+      decreases(rules)
 
       rules match {
         case Cons(hd, tl) if hd == rSep =>
@@ -1473,6 +1489,7 @@ object VerifiedLexer {
       require(rulesInvariant(rules))
       require(tokens.contains(t))
       require(rulesProduceEachTokenIndividually(rules, tokens))
+      decreases(tokens)
 
       tokens match {
         case Cons(hd, tl) if hd == t => ()

--- a/lexers/regex/VerifiedRegex.scala
+++ b/lexers/regex/VerifiedRegex.scala
@@ -20,13 +20,16 @@ object VerifiedRegex {
     case EmptyLang()        => true
   }
 
-  def regexDepth[C](r: Regex[C]): BigInt = r match {
-    case ElementMatch(c)    => BigInt(1)
-    case Star(r)            => BigInt(1) + regexDepth(r)
-    case Union(rOne, rTwo)  => BigInt(1) + Utils.maxBigInt(regexDepth(rOne), regexDepth(rTwo))
-    case Concat(rOne, rTwo) => BigInt(1) + Utils.maxBigInt(regexDepth(rOne), regexDepth(rTwo))
-    case EmptyExpr()        => BigInt(1)
-    case EmptyLang()        => BigInt(1)
+  def regexDepth[C](r: Regex[C]): BigInt = {
+    decreases(r)
+    r match {
+      case ElementMatch(c)    => BigInt(1)
+      case Star(r)            => BigInt(1) + regexDepth(r)
+      case Union(rOne, rTwo)  => BigInt(1) + Utils.maxBigInt(regexDepth(rOne), regexDepth(rTwo))
+      case Concat(rOne, rTwo) => BigInt(1) + Utils.maxBigInt(regexDepth(rOne), regexDepth(rTwo))
+      case EmptyExpr()        => BigInt(1)
+      case EmptyLang()        => BigInt(1)
+    }
   }
 
   case class ElementMatch[C](c: C) extends Regex[C]
@@ -83,6 +86,7 @@ object VerifiedRegexMatcher {
 
   def derivativeStep[C](r: Regex[C], a: C): Regex[C] = {
     require(validRegex(r))
+    decreases(r)
     val res: Regex[C] = r match {
       case EmptyExpr()       => EmptyLang()
       case EmptyLang()       => EmptyLang()
@@ -432,6 +436,7 @@ object VerifiedRegexMatcher {
     require(validRegex(r1) && validRegex(r2))
     require(matchR(r1, s1))
     require(matchR(r2, s2))
+    decreases(s1)
 
     s1 match {
       case Cons(hd, tl) => {
@@ -526,6 +531,7 @@ object VerifiedRegexMatcher {
     require(validRegex(r1))
     require(validRegex(r2))
     require(matchR(Concat(r1, r2), s))
+    decreases(s)
 
     val r = Concat(r1, r2)
     s match {
@@ -587,6 +593,7 @@ object VerifiedRegexMatcher {
     require(validRegex(r))
     require(s.contains(c))
     require(!usedCharacters(r).contains(c))
+    decreases(s)
 
     s match {
       case Cons(hd, tl) if hd == c => lemmaRegexCannotMatchAStringStartingWithACharItDoesNotContain(r, s, c)
@@ -632,6 +639,7 @@ object VerifiedRegexMatcher {
     require(validRegex(r))
     require(!nullable(r))
     require(nullable(derivativeStep(r, c)))
+    decreases(r)
 
     r match {
       case EmptyExpr()     => check(false)
@@ -673,6 +681,7 @@ object VerifiedRegexMatcher {
   def lemmaDerivativeAfterDerivativeStepIsNullableThenUsedCharsContainsHead[C](r: Regex[C], c: C, tl: List[C]): Unit = {
     require(validRegex(r))
     require(nullable(derivative(derivativeStep(r, c), tl)))
+    decreases(r)
 
     r match {
       case EmptyExpr() => {
@@ -814,6 +823,7 @@ object VerifiedRegexMatcher {
   def lemmaUsedCharsContainsAllFirstChars[C](r: Regex[C], c: C): Unit = {
     require(validRegex(r))
     require(firstChars(r).contains(c))
+    decreases(r)
     r match {
       case EmptyExpr()     => ()
       case EmptyLang()     => ()
@@ -841,6 +851,7 @@ object VerifiedRegexMatcher {
   def lemmaDerivAfterDerivStepIsNullableThenFirstCharsContainsHead[C](r: Regex[C], c: C, tl: List[C]): Unit = {
     require(validRegex(r))
     require(nullable(derivative(derivativeStep(r, c), tl)))
+    decreases(r)
 
     r match {
       case EmptyExpr() => {


### PR DESCRIPTION
A VC could not be solved on `laraquad4` with `stainless-scalac`. I couldn't reproduce it on my machine. It seems that `MeasureInference` inferred one or more measures (on `laraquad4`) that do not play nicely with the failing VC.