### PR TITLE
Add 'Scala 3 only' benchmarks in running scripts

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -29,11 +29,23 @@ function run_tests {
   echo ""
 }
 
-# Tests that use the usual --type-checker=true verification condition generator:
+# Determining the frontend version
+OUTPUT=$($STAINLESS --version --no-colors)
+VERSION=$(echo "${OUTPUT}" | awk '/^Bundled Scala compiler: /{print $4}')
+IS_DOTTY=false
+if [[ $VERSION == 3\.* ]]; then
+  IS_DOTTY=true
+elif [[ $VERSION != 2\.* ]]; then
+  echo "Could not recognize Stainless frontend version"
+  exit 1
+fi
 
 TC_TESTS=`cat tctests.txt`
-echo **************************
-echo Type Checking vcgen tests:
+if [[ "$IS_DOTTY" = true ]]; then
+  TC_TESTS=$(cat tctests_dotty.txt)$'\n'$TC_TESTS
+fi
+echo "**************************"
+echo "Type Checking vcgen tests:"
 echo $TC_TESTS
 for project in $TC_TESTS; do
   run_tests "$project" "--config-file=stainless.conf.nightly"

--- a/tctests.txt
+++ b/tctests.txt
@@ -1,4 +1,3 @@
-algorithms/aggregate-correct
 algorithms/sorting
 algorithms/fulcrum
 algorithms/leftpad
@@ -9,7 +8,6 @@ data-structures/amortized-queue2
 data-structures/lisp
 data-structures/trees/concrope
 data-structures/trees/redblack
-data-structures/trees/simple-conc
 expression-compiler
 fp-principles/example
 fp-principles/functional-sets

--- a/tctests_dotty.txt
+++ b/tctests_dotty.txt
@@ -1,0 +1,2 @@
+algorithms/aggregate-correct
+data-structures/trees/simple-conc


### PR DESCRIPTION
This allows to skip Scala 3 benchmarks when running with `stainless-scalac`.