### PR TITLE
Add a trait interface to the `MutableLongMap` as a first step towards modular proofs

### DIFF
--- a/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/ListMap.scala
+++ b/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/ListMap.scala
@@ -17,7 +17,7 @@ import scala.collection.mutable
 // import OptimisedChecks.*
 
 case class ListMap[K, B](toList: List[(K, B)]) {
-  require(TupleListOpsGenK.noDuplicatedKeys(toList))
+  require(TupleListOpsGenK.invariantList(toList))
 
   def isEmpty: Boolean = toList.isEmpty
 

--- a/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/MutableHashMap.scala
+++ b/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/MutableHashMap.scala
@@ -242,7 +242,7 @@ object MutableHashMap {
     def map: ListMap[K, V] = {
       require(valid)
       extractMap(underlying.v.map.toList)
-    }
+    }.ensuring(res => TupleListOpsGenK.invariantList(res))
 
   }
   @ghost
@@ -253,7 +253,7 @@ object MutableHashMap {
       case Cons((k, v), tl) => addToMapMapFromBucket(v, extractMap(tl))
       case Nil()            => ListMap.empty[K, V]
     }
-  }.ensuring (res => true)
+  }.ensuring (res => TupleListOpsGenK.invariantList(res))
 
   @ghost
   def addToMapMapFromBucket[K, V](l: List[(K, V)], acc: ListMap[K, V]): ListMap[K, V] = {
@@ -285,7 +285,7 @@ object MutableHashMap {
         res
       }
     }
-  }.ensuring (res => l.forall(p => res.contains(p._1)) && acc.toList.forall(p => res.contains(p._1)))
+  }.ensuring (res => l.forall(p => res.contains(p._1)) && acc.toList.forall(p => res.contains(p._1)) && TupleListOpsGenK.invariantList(res))
 
   @ghost
   def noDuplicateKeys[K, V](l: List[(K, V)]): Boolean = {

--- a/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/MutableHashMap.scala
+++ b/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/MutableHashMap.scala
@@ -242,7 +242,7 @@ object MutableHashMap {
     def map: ListMap[K, V] = {
       require(valid)
       extractMap(underlying.v.map.toList)
-    }.ensuring(res => TupleListOpsGenK.invariantList(res))
+    }.ensuring(res => TupleListOpsGenK.invariantList(res.toList))
 
   }
   @ghost
@@ -253,7 +253,7 @@ object MutableHashMap {
       case Cons((k, v), tl) => addToMapMapFromBucket(v, extractMap(tl))
       case Nil()            => ListMap.empty[K, V]
     }
-  }.ensuring (res => TupleListOpsGenK.invariantList(res))
+  }.ensuring (res => TupleListOpsGenK.invariantList(res.toList))
 
   @ghost
   def addToMapMapFromBucket[K, V](l: List[(K, V)], acc: ListMap[K, V]): ListMap[K, V] = {
@@ -285,7 +285,7 @@ object MutableHashMap {
         res
       }
     }
-  }.ensuring (res => l.forall(p => res.contains(p._1)) && acc.toList.forall(p => res.contains(p._1)) && TupleListOpsGenK.invariantList(res))
+  }.ensuring (res => l.forall(p => res.contains(p._1)) && acc.toList.forall(p => res.contains(p._1)) && TupleListOpsGenK.invariantList(res.toList))
 
   @ghost
   def noDuplicateKeys[K, V](l: List[(K, V)]): Boolean = {

--- a/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/MutableLongMap.scala
+++ b/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/MutableLongMap.scala
@@ -14,6 +14,69 @@ import ch.epfl.chassot.MutableMapInterface.MLongMap
 import stainless.lang.StaticChecks.* // Comment out when using the OptimisedEnsuring object below
 // import OptimisedChecks.* // Import to remove `ensuring` and `require` from the code for the benchmarks
 
+
+object MutableMapInterface{
+  @mutable
+  sealed trait MLongMap[V] {
+    @pure
+    def defaultEntry: Long => V
+    /**
+     * @return an instance of the executable specification of the map
+     */
+    @ghost
+    @pure
+    def abstractMap: ListLongMap[V]
+
+    @pure
+    def size: Int
+    @pure
+    def isEmpty: Boolean
+    @pure
+    def contains(key: Long): Boolean
+    @pure
+    def apply(key: Long): V
+
+    def update(key: Long, v: V): Boolean 
+    def remove(key: Long): Boolean
+
+    @ghost @pure 
+    @law def containsCorrect(key: Long): Boolean = 
+      val thiss = snapshot(this)
+      thiss.contains(key) == thiss.abstractMap.contains(key)
+    
+    @ghost @pure 
+    @law def applyCorrect(key: Long): Boolean = 
+      val res = apply(key)
+      if (contains(key)) then 
+        abstractMap.get(key).isDefined
+        && res == abstractMap.get(key).get
+      else 
+        res == defaultEntry(key)
+    
+    @ghost @pure 
+    @law def updateCorrect(key: Long, v: V): Boolean = 
+      val thiss = snapshot(this)
+      val oldMap = abstractMap
+      val res = thiss.update(key, v)
+      if (res) then
+        thiss.abstractMap.contains(key) 
+        && (thiss.abstractMap == oldMap + (key, v))
+      else 
+        thiss.abstractMap == oldMap
+
+    @ghost @pure 
+    @law def removeCorrect(key: Long): Boolean = 
+      val thiss = snapshot(this)
+      val oldMap = thiss.abstractMap
+      val res = thiss.remove(key)
+      if (res) then
+        thiss.abstractMap == oldMap - key
+      else 
+        thiss.abstractMap == oldMap
+
+  }
+}
+
 object MutableLongMap {
   import LongMapFixedSize.validMask
 

--- a/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/MutableLongMap.scala
+++ b/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/MutableLongMap.scala
@@ -13,72 +13,10 @@ import stainless.lang.Cell
 import stainless.lang.StaticChecks.* // Comment out when using the OptimisedEnsuring object below
 // import OptimisedChecks.* // Import to remove `ensuring` and `require` from the code for the benchmarks
 
-
-object MutableMapInterface{
-  @mutable
-  trait iMLongMap[V] {
-    @pure
-    def defaultEntry: Long => V
-    /**
-     * @return an instance of the executable specification of the map
-     */
-    @ghost
-    @pure
-    def abstractMap: ListLongMap[V]
-
-    @pure
-    def size: Int
-    @pure
-    def isEmpty: Boolean
-    @pure
-    def contains(key: Long): Boolean
-    @pure
-    def apply(key: Long): V
-
-    def update(key: Long, v: V): Boolean 
-    def remove(key: Long): Boolean
-
-    @ghost @pure 
-    @law def containsCorrect(key: Long): Boolean = 
-      val thiss = snapshot(this)
-      thiss.contains(key) == thiss.abstractMap.contains(key)
-    
-    @ghost @pure 
-    @law def applyCorrect(key: Long): Boolean = 
-      val res = apply(key)
-      if (contains(key)) then 
-        abstractMap.get(key).isDefined
-        && res == abstractMap.get(key).get
-      else 
-        res == defaultEntry(key)
-    
-    @ghost @pure 
-    @law def updateCorrect(key: Long, v: V): Boolean = 
-      val thiss = snapshot(this)
-      val oldMap = abstractMap
-      val res = thiss.update(key, v)
-      if (res) then
-        thiss.abstractMap.contains(key) 
-        && (thiss.abstractMap == oldMap + (key, v))
-      else 
-        thiss.abstractMap == oldMap
-
-    @ghost @pure 
-    @law def removeCorrect(key: Long): Boolean = 
-      val thiss = snapshot(this)
-      val oldMap = thiss.abstractMap
-      val res = thiss.remove(key)
-      if (res) then
-        thiss.abstractMap == oldMap - key
-      else 
-        thiss.abstractMap == oldMap
-
-  }
-}
+import MutableMapInterface.iMLongMap
 
 object MutableLongMap {
   import LongMapFixedSize.validMask
-  import MutableMapInterface.iMLongMap
 
   /** Helper method to create a new empty LongMap
     *

--- a/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/MutableLongMap.scala
+++ b/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/MutableLongMap.scala
@@ -9,7 +9,6 @@ import stainless.lang.{ghost => ghostExpr, *}
 import stainless.proof.check
 import scala.annotation.tailrec
 import stainless.lang.Cell
-import ch.epfl.chassot.MutableMapInterface.MLongMap
 
 import stainless.lang.StaticChecks.* // Comment out when using the OptimisedEnsuring object below
 // import OptimisedChecks.* // Import to remove `ensuring` and `require` from the code for the benchmarks
@@ -17,7 +16,7 @@ import stainless.lang.StaticChecks.* // Comment out when using the OptimisedEnsu
 
 object MutableMapInterface{
   @mutable
-  sealed trait MLongMap[V] {
+  trait iMLongMap[V] {
     @pure
     def defaultEntry: Long => V
     /**
@@ -79,6 +78,7 @@ object MutableMapInterface{
 
 object MutableLongMap {
   import LongMapFixedSize.validMask
+  import MutableMapInterface.iMLongMap
 
   /** Helper method to create a new empty LongMap
     *
@@ -106,7 +106,7 @@ object MutableLongMap {
   @mutable
   final case class LongMap[V](
       val underlying: Cell[LongMapFixedSize[V]]
-  ) extends MLongMap[V] {
+  ) extends iMLongMap[V] {
 
     @pure
     override def defaultEntry: Long => V = underlying.v.defaultEntry

--- a/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/iMutableLongMap.scala
+++ b/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/iMutableLongMap.scala
@@ -1,0 +1,75 @@
+/** Author: Samuel Chassot
+  */
+package ch.epfl.chassot
+
+import stainless.annotation._
+import stainless.collection._
+import stainless.equations._
+import stainless.lang.{ghost => ghostExpr, *}
+import stainless.proof.check
+import scala.annotation.tailrec
+import stainless.lang.Cell
+
+import stainless.lang.StaticChecks.* // Comment out when using the OptimisedEnsuring object below
+
+object MutableMapInterface{
+  @mutable
+  trait MLongMap[V] {
+    @pure
+    def defaultEntry: Long => V
+    /**
+     * @return an instance of the executable specification of the map
+     */
+    @ghost
+    @pure
+    def abstractMap: ListLongMap[V]
+
+    @pure
+    def size: Int
+    @pure
+    def isEmpty: Boolean
+    @pure
+    def contains(key: Long): Boolean
+    @pure
+    def apply(key: Long): V
+
+    def update(key: Long, v: V): Boolean 
+    def remove(key: Long): Boolean
+
+    @law @ghost @pure 
+    def containsCorrect(key: Long): Boolean = 
+      val thiss = snapshot(this)
+      thiss.contains(key) == thiss.abstractMap.contains(key)
+    
+    @law @ghost @pure 
+    def applyCorrect(key: Long): Boolean = 
+      val res = apply(key)
+      if (contains(key)) then 
+        abstractMap.get(key).isDefined
+        && res == abstractMap.get(key).get
+      else 
+        res == defaultEntry(key)
+    
+    @law @ghost @pure 
+    def updateCorrect(key: Long, v: V): Boolean = 
+      val thiss = snapshot(this)
+      val oldMap = abstractMap
+      val res = thiss.update(key, v)
+      if (res) then
+        thiss.abstractMap.contains(key) 
+        && (thiss.abstractMap == oldMap + (key, v))
+      else 
+        thiss.abstractMap == oldMap
+
+    @law @ghost @pure 
+    def removeCorrect(key: Long): Boolean = 
+      val thiss = snapshot(this)
+      val oldMap = thiss.abstractMap
+      val res = thiss.remove(key)
+      if (res) then
+        thiss.abstractMap == oldMap - key
+      else 
+        thiss.abstractMap == oldMap
+
+  }
+}

--- a/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/iMutableLongMap.scala
+++ b/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/iMutableLongMap.scala
@@ -14,62 +14,92 @@ import stainless.lang.StaticChecks.* // Comment out when using the OptimisedEnsu
 
 object MutableMapInterface{
   @mutable
-  trait MLongMap[V] {
+  trait iMLongMap[V] {
+    
+    /**
+     * Invariant for the datastructure
+     */
+    @pure 
+    @ghost
+    def valid: Boolean
+    
     @pure
     def defaultEntry: Long => V
+
     /**
      * @return an instance of the executable specification of the map
      */
     @ghost
     @pure
-    def abstractMap: ListLongMap[V]
+    def abstractMap: ListLongMap[V] = {
+      require(valid)
+      ??? : ListLongMap[V]
+    }
 
     @pure
     def size: Int
     @pure
-    def isEmpty: Boolean
+    def isEmpty: Boolean = {
+      require(valid)
+      ??? : Boolean
+    }
+
     @pure
-    def contains(key: Long): Boolean
+    def contains(key: Long): Boolean = {
+    require(valid)
+    ??? : Boolean
+    }.ensuring(res => valid && (res == abstractMap.contains(key)))
+
     @pure
-    def apply(key: Long): V
+    def apply(key: Long): V = {
+      require(valid)
+      ??? : V
+    }.ensuring(res => valid && (if (contains(key)) then abstractMap.get(key).isDefined && res == abstractMap.get(key).get else res == defaultEntry(key)))
 
-    def update(key: Long, v: V): Boolean 
-    def remove(key: Long): Boolean
-
-    @ghost @pure 
-    @law def containsCorrect(key: Long): Boolean = 
-      val thiss = snapshot(this)
-      thiss.contains(key) == thiss.abstractMap.contains(key)
+    def update(key: Long, v: V): Boolean = {
+      require(valid)
+      ??? : Boolean
+    }.ensuring(res => valid && (if (res) then abstractMap.contains(key) && (abstractMap == old(this).abstractMap + (key, v)) else abstractMap == old(this).abstractMap))
     
-    @ghost @pure 
-    @law def applyCorrect(key: Long): Boolean = 
-      val res = apply(key)
-      if (contains(key)) then 
-        abstractMap.get(key).isDefined
-        && res == abstractMap.get(key).get
-      else 
-        res == defaultEntry(key)
-    
-    @ghost @pure 
-    @law def updateCorrect(key: Long, v: V): Boolean = 
-      val thiss = snapshot(this)
-      val oldMap = abstractMap
-      val res = thiss.update(key, v)
-      if (res) then
-        thiss.abstractMap.contains(key) 
-        && (thiss.abstractMap == oldMap + (key, v))
-      else 
-        thiss.abstractMap == oldMap
+    def remove(key: Long): Boolean = {
+      require(valid)
+      ??? : Boolean
+    }.ensuring(res => valid && (if (res) then abstractMap == old(this).abstractMap - key else abstractMap == old(this).abstractMap))
 
-    @ghost @pure 
-    @law def removeCorrect(key: Long): Boolean = 
-      val thiss = snapshot(this)
-      val oldMap = thiss.abstractMap
-      val res = thiss.remove(key)
-      if (res) then
-        thiss.abstractMap == oldMap - key
-      else 
-        thiss.abstractMap == oldMap
+    // @ghost @pure 
+    // @law def containsCorrect(key: Long): Boolean = 
+    //   val thiss = snapshot(this)
+    //   thiss.contains(key) == thiss.abstractMap.contains(key)
+    
+    // @ghost @pure 
+    // @law def applyCorrect(key: Long): Boolean = 
+    //   val res = apply(key)
+    //   if (contains(key)) then 
+    //     abstractMap.get(key).isDefined
+    //     && res == abstractMap.get(key).get
+    //   else 
+    //     res == defaultEntry(key)
+    
+    // @ghost @pure 
+    // @law def updateCorrect(key: Long, v: V): Boolean = 
+    //   val thiss = snapshot(this)
+    //   val oldMap = abstractMap
+    //   val res = thiss.update(key, v)
+    //   if (res) then
+    //     thiss.abstractMap.contains(key) 
+    //     && (thiss.abstractMap == oldMap + (key, v))
+    //   else 
+    //     thiss.abstractMap == oldMap
+
+    // @ghost @pure 
+    // @law def removeCorrect(key: Long): Boolean = 
+    //   val thiss = snapshot(this)
+    //   val oldMap = thiss.abstractMap
+    //   val res = thiss.remove(key)
+    //   if (res) then
+    //     thiss.abstractMap == oldMap - key
+    //   else 
+    //     thiss.abstractMap == oldMap
 
   }
 }

--- a/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/iMutableLongMap.scala
+++ b/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/iMutableLongMap.scala
@@ -36,13 +36,13 @@ object MutableMapInterface{
     def update(key: Long, v: V): Boolean 
     def remove(key: Long): Boolean
 
-    @law @ghost @pure 
-    def containsCorrect(key: Long): Boolean = 
+    @ghost @pure 
+    @law def containsCorrect(key: Long): Boolean = 
       val thiss = snapshot(this)
       thiss.contains(key) == thiss.abstractMap.contains(key)
     
-    @law @ghost @pure 
-    def applyCorrect(key: Long): Boolean = 
+    @ghost @pure 
+    @law def applyCorrect(key: Long): Boolean = 
       val res = apply(key)
       if (contains(key)) then 
         abstractMap.get(key).isDefined
@@ -50,8 +50,8 @@ object MutableMapInterface{
       else 
         res == defaultEntry(key)
     
-    @law @ghost @pure 
-    def updateCorrect(key: Long, v: V): Boolean = 
+    @ghost @pure 
+    @law def updateCorrect(key: Long, v: V): Boolean = 
       val thiss = snapshot(this)
       val oldMap = abstractMap
       val res = thiss.update(key, v)
@@ -61,8 +61,8 @@ object MutableMapInterface{
       else 
         thiss.abstractMap == oldMap
 
-    @law @ghost @pure 
-    def removeCorrect(key: Long): Boolean = 
+    @ghost @pure 
+    @law def removeCorrect(key: Long): Boolean = 
       val thiss = snapshot(this)
       val oldMap = thiss.abstractMap
       val res = thiss.remove(key)

--- a/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/iMutableMaps.scala
+++ b/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/iMutableMaps.scala
@@ -58,12 +58,12 @@ object MutableMapInterface{
     def update(key: Long, v: V): Boolean = {
       require(valid)
       ??? : Boolean
-    }.ensuring(res => valid && (if (res) then abstractMap.contains(key) && (abstractMap.eq(old(this).abstractMap + (key, v))) else abstractMap.eq(old(this).abstractMap)))
+    }.ensuring(res => valid && (if (res) then abstractMap.contains(key) && (abstractMap == old(this).abstractMap + (key, v)) else abstractMap == old(this).abstractMap))
     
     def remove(key: Long): Boolean = {
       require(valid)
       ??? : Boolean
-    }.ensuring(res => valid && (if (res) then abstractMap.eq(old(this).abstractMap - key) else abstractMap.eq(old(this).abstractMap)))
+    }.ensuring(res => valid && (if (res) then abstractMap == old(this).abstractMap - key else abstractMap == old(this).abstractMap))
   }
 
   @mutable
@@ -112,11 +112,11 @@ object MutableMapInterface{
     def update(key: K, v: V): Boolean = {
       require(valid)
       ??? : Boolean
-    }.ensuring(res => valid && (if (res) then abstractMap.contains(key) && (abstractMap == old(this).abstractMap + (key, v)) else abstractMap == old(this).abstractMap))
+    }.ensuring(res => valid && (if (res) then abstractMap.contains(key) && (abstractMap.eq(old(this).abstractMap + (key, v))) else abstractMap.eq(old(this).abstractMap)))
     
     def remove(key: K): Boolean = {
       require(valid)
       ??? : Boolean
-    }.ensuring(res => valid && (if (res) then abstractMap == old(this).abstractMap - key else abstractMap == old(this).abstractMap))
+    }.ensuring(res => valid && (if (res) then abstractMap.eq(old(this).abstractMap - key) else abstractMap.eq(old(this).abstractMap)))
   }
 }

--- a/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/iMutableMaps.scala
+++ b/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/iMutableMaps.scala
@@ -58,12 +58,12 @@ object MutableMapInterface{
     def update(key: Long, v: V): Boolean = {
       require(valid)
       ??? : Boolean
-    }.ensuring(res => valid && (if (res) then abstractMap.contains(key) && (abstractMap == old(this).abstractMap + (key, v)) else abstractMap == old(this).abstractMap))
+    }.ensuring(res => valid && (if (res) then abstractMap.contains(key) && (abstractMap.eq(old(this).abstractMap + (key, v))) else abstractMap.eq(old(this).abstractMap)))
     
     def remove(key: Long): Boolean = {
       require(valid)
       ??? : Boolean
-    }.ensuring(res => valid && (if (res) then abstractMap == old(this).abstractMap - key else abstractMap == old(this).abstractMap))
+    }.ensuring(res => valid && (if (res) then abstractMap.eq(old(this).abstractMap - key) else abstractMap.eq(old(this).abstractMap)))
   }
 
   @mutable

--- a/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/iMutableMaps.scala
+++ b/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/iMutableMaps.scala
@@ -15,7 +15,6 @@ import stainless.lang.StaticChecks.* // Comment out when using the OptimisedEnsu
 object MutableMapInterface{
   @mutable
   trait iMLongMap[V] {
-    
     /**
      * Invariant for the datastructure
      */
@@ -65,41 +64,59 @@ object MutableMapInterface{
       require(valid)
       ??? : Boolean
     }.ensuring(res => valid && (if (res) then abstractMap == old(this).abstractMap - key else abstractMap == old(this).abstractMap))
+  }
 
-    // @ghost @pure 
-    // @law def containsCorrect(key: Long): Boolean = 
-    //   val thiss = snapshot(this)
-    //   thiss.contains(key) == thiss.abstractMap.contains(key)
+  @mutable
+  trait iMHashMap[K, V] {
+    import ch.epfl.chassot.ListMap
+    /**
+     * Invariant for the datastructure
+     */
+    @pure 
+    @ghost
+    def valid: Boolean
     
-    // @ghost @pure 
-    // @law def applyCorrect(key: Long): Boolean = 
-    //   val res = apply(key)
-    //   if (contains(key)) then 
-    //     abstractMap.get(key).isDefined
-    //     && res == abstractMap.get(key).get
-    //   else 
-    //     res == defaultEntry(key)
+    @pure
+    def defaultEntry: K => V
+
+    /**
+     * @return an instance of the executable specification of the map
+     */
+    @ghost
+    @pure
+    def abstractMap: ListMap[K, V] = {
+      require(valid)
+      ??? : ListMap[K, V]
+    }
+
+    @pure
+    def size: Int
+    @pure
+    def isEmpty: Boolean = {
+      require(valid)
+      ??? : Boolean
+    }
+
+    @pure
+    def contains(key: K): Boolean = {
+    require(valid)
+    ??? : Boolean
+    }.ensuring(res => valid && (res == abstractMap.contains(key)))
+
+    @pure
+    def apply(key: K): V = {
+      require(valid)
+      ??? : V
+    }.ensuring(res => valid && (if (contains(key)) then abstractMap.get(key).isDefined && res == abstractMap.get(key).get else res == defaultEntry(key)))
+
+    def update(key: K, v: V): Boolean = {
+      require(valid)
+      ??? : Boolean
+    }.ensuring(res => valid && (if (res) then abstractMap.contains(key) && (abstractMap == old(this).abstractMap + (key, v)) else abstractMap == old(this).abstractMap))
     
-    // @ghost @pure 
-    // @law def updateCorrect(key: Long, v: V): Boolean = 
-    //   val thiss = snapshot(this)
-    //   val oldMap = abstractMap
-    //   val res = thiss.update(key, v)
-    //   if (res) then
-    //     thiss.abstractMap.contains(key) 
-    //     && (thiss.abstractMap == oldMap + (key, v))
-    //   else 
-    //     thiss.abstractMap == oldMap
-
-    // @ghost @pure 
-    // @law def removeCorrect(key: Long): Boolean = 
-    //   val thiss = snapshot(this)
-    //   val oldMap = thiss.abstractMap
-    //   val res = thiss.remove(key)
-    //   if (res) then
-    //     thiss.abstractMap == oldMap - key
-    //   else 
-    //     thiss.abstractMap == oldMap
-
+    def remove(key: K): Boolean = {
+      require(valid)
+      ??? : Boolean
+    }.ensuring(res => valid && (if (res) then abstractMap == old(this).abstractMap - key else abstractMap == old(this).abstractMap))
   }
 }

--- a/data-structures/maps/mutablemaps/stainless.conf
+++ b/data-structures/maps/mutablemaps/stainless.conf
@@ -4,7 +4,7 @@
 
 vc-cache            = true
 # debug               = ["verification", "smt"]
-timeout             = 90
+timeout             = 180
 check-models        = false
 print-ids           = false
 print-types         = false

--- a/data-structures/maps/mutablemaps/verify.sh
+++ b/data-structures/maps/mutablemaps/verify.sh
@@ -2,5 +2,6 @@ stainless-dotty\
  ./src/main/scala/ch/epfl/chassot/ListMap.scala\
  ./src/main/scala/ch/epfl/chassot/ListLongMap.scala\
  ./src/main/scala/ch/epfl/chassot/MutableLongMap.scala\
+ ./src/main/scala/ch/epfl/chassot/iMutableLongMap.scala\
  ./src/main/scala/ch/epfl/chassot/MutableHashMap.scala\
   --config-file=stainless.conf -Dparallel=4 $1

--- a/data-structures/maps/mutablemaps/verify.sh
+++ b/data-structures/maps/mutablemaps/verify.sh
@@ -4,4 +4,4 @@ stainless-dotty\
  ./src/main/scala/ch/epfl/chassot/MutableLongMap.scala\
  ./src/main/scala/ch/epfl/chassot/MutableHashMap.scala\
  ./src/main/scala/ch/epfl/chassot/iMutableMaps.scala\
-  --config-file=stainless.conf -Dparallel=2 $1
+  --config-file=stainless.conf -Dparallel=6 $1

--- a/data-structures/maps/mutablemaps/verify.sh
+++ b/data-structures/maps/mutablemaps/verify.sh
@@ -1,1 +1,7 @@
-stainless-dotty ./src/main/scala/ch/epfl/chassot/ListMap.scala ./src/main/scala/ch/epfl/chassot/ListLongMap.scala ./src/main/scala/ch/epfl/chassot/MutableLongMap.scala  ./src/main/scala/ch/epfl/chassot/MutableHashMap.scala --config-file=stainless.conf -Dparallel=4 $1
+stainless-dotty\
+ ./src/main/scala/ch/epfl/chassot/ListMap.scala\
+ ./src/main/scala/ch/epfl/chassot/ListLongMap.scala\
+ ./src/main/scala/ch/epfl/chassot/iMutableLongMap.scala\
+ ./src/main/scala/ch/epfl/chassot/MutableLongMap.scala\
+ ./src/main/scala/ch/epfl/chassot/MutableHashMap.scala\
+  --config-file=stainless.conf -Dparallel=4 $1

--- a/data-structures/maps/mutablemaps/verify.sh
+++ b/data-structures/maps/mutablemaps/verify.sh
@@ -1,7 +1,6 @@
 stainless-dotty\
  ./src/main/scala/ch/epfl/chassot/ListMap.scala\
  ./src/main/scala/ch/epfl/chassot/ListLongMap.scala\
- ./src/main/scala/ch/epfl/chassot/iMutableLongMap.scala\
  ./src/main/scala/ch/epfl/chassot/MutableLongMap.scala\
  ./src/main/scala/ch/epfl/chassot/MutableHashMap.scala\
   --config-file=stainless.conf -Dparallel=4 $1

--- a/data-structures/maps/mutablemaps/verify.sh
+++ b/data-structures/maps/mutablemaps/verify.sh
@@ -2,6 +2,6 @@ stainless-dotty\
  ./src/main/scala/ch/epfl/chassot/ListMap.scala\
  ./src/main/scala/ch/epfl/chassot/ListLongMap.scala\
  ./src/main/scala/ch/epfl/chassot/MutableLongMap.scala\
- ./src/main/scala/ch/epfl/chassot/iMutableLongMap.scala\
  ./src/main/scala/ch/epfl/chassot/MutableHashMap.scala\
-  --config-file=stainless.conf -Dparallel=4 $1
+ ./src/main/scala/ch/epfl/chassot/iMutableMaps.scala\
+  --config-file=stainless.conf -Dparallel=2 $1


### PR DESCRIPTION
The interface is a trait that uses laws to express the specifications of the map.

For now, the verification does not go through because of a require added to the function calls:
For example, `def abstractMap` looks like this in the trees:
```
[ Debug  ] @ghost
[ Debug  ] def abstractMap[V](thiss: MLongMap[V]): ListLongMap[V] = {
[ Debug  ]   require(thiss.isInstanceOf[LongMap])
[ Debug  ]   require((valid[V](thiss)): @ghost )
[ Debug  ]   map[V](thiss)
[ Debug  ] }
```
And the VC for the 2nd require is invalid. It shouldn't appear in the first place.

I'll build a smaller example to debug this.