### PR TITLE
Example of abstraction using methods with ???. Needs some systematic checks for missing implementations

### DIFF
--- a/data-structures/mutable-set/list-nodup-abstract-class/MutableSet.scala
+++ b/data-structures/mutable-set/list-nodup-abstract-class/MutableSet.scala
@@ -1,0 +1,42 @@
+package modularity
+
+import stainless.collection._
+import stainless.lang._
+import stainless.annotation._
+
+object MutableSetImplObj:
+
+  @mutable
+  final case class MutableSetImpl[V](private var list: List[V]) extends MutableSetObj.MutableSet[V]:
+    require(ListSpecs.noDuplicate(list))
+
+    override def toSet = list.content
+
+    override def contains(v: V): Boolean = list.contains(v)
+    
+    override def add(v: V): Unit =
+      if !list.contains(v) then
+        list = v :: list
+      else 
+        ()
+
+    override def remove(v: V): Unit = 
+      list = removeElement(list, v)
+
+    private def removeElement(l: List[V], v: V): List[V] = {
+      require(ListSpecs.noDuplicate(l))
+      l match
+        case Nil() => Nil[V]()
+        case Cons(h, t) if h == v => t
+        case Cons(h, t) => Cons(h, removeElement(t, v))
+      }.ensuring(res =>
+        !res.contains(v)
+        && ListSpecs.noDuplicate(res)
+        && res.content == l.content -- Set(v)
+        && (if l.contains(v) then res.size == l.size - 1 else res.size == l.size)
+    )
+
+    override def size: BigInt = 
+      list.size
+
+end MutableSetImplObj

--- a/data-structures/mutable-set/list-nodup-abstract-class/iMutableSet.scala
+++ b/data-structures/mutable-set/list-nodup-abstract-class/iMutableSet.scala
@@ -1,0 +1,44 @@
+package modularity
+
+
+import stainless.collection._
+import stainless.lang._
+import stainless.annotation._
+
+
+object MutableSetObj:
+  @mutable
+  trait MutableSet[V]:
+    @pure
+    def toSet: Set[V]
+
+    @pure
+    def contains(v: V): Boolean = {
+      ??? : Boolean
+    } ensuring(_ == toSet.contains(v))
+
+    def add(v: V): Unit = {
+      ??? : Unit
+    } ensuring(() => 
+        toSet == old(this).toSet + v &&
+        (if old(this).contains(v) then 
+          size == old(this).size
+        else
+          size == old(this).size + 1))
+
+    def remove(v: V): Unit = {
+      ??? : Unit
+    } ensuring(() => 
+        toSet == old(this).toSet - v &&
+        (if old(this).contains(v) then 
+          size == old(this).size - 1
+        else
+          size == old(this).size))
+
+    @pure
+    def size: BigInt = {
+      ??? : BigInt
+    } ensuring(_ >= 0)
+
+  end MutableSet
+end MutableSetObj

--- a/data-structures/mutable-set/list-nodup-abstract-class/iMutableSet.scala
+++ b/data-structures/mutable-set/list-nodup-abstract-class/iMutableSet.scala
@@ -10,7 +10,9 @@ object MutableSetObj:
   @mutable
   trait MutableSet[V]:
     @pure
-    def toSet: Set[V]
+    def toSet: Set[V] = {
+      ??? : Set[V]
+    }
 
     @pure
     def contains(v: V): Boolean = {
@@ -41,4 +43,9 @@ object MutableSetObj:
     } ensuring(_ >= 0)
 
   end MutableSet
+
+  def test =
+    val ms = new MutableSet[Int] {}
+    true
+
 end MutableSetObj

--- a/data-structures/mutable-set/list-nodup-abstract-class/stainless.conf
+++ b/data-structures/mutable-set/list-nodup-abstract-class/stainless.conf
@@ -1,0 +1,15 @@
+# The settings below correspond to the various
+# options listed by `stainless --help`
+
+vc-cache            = true
+# debug               = ["verification", "smt"]
+timeout             = 15
+check-models        = false
+print-ids           = false
+print-types         = false
+batched             = true
+strict-arithmetic   = false
+solvers             = "smt-cvc5,smt-z3,smt-cvc4"
+check-measures      = yes
+infer-measures      = true
+simplifier           = "ol"


### PR DESCRIPTION
Using laws is more expressive, but is rather verbose for mutable classes.
This seems much simpler, especially when there is an abstraction function for the state.

However, Stainless should prevent such classes with `???` methods to be used when they are not `extern`.

This is currently not the case. Instead, if there are any instances of such trait, stainless will permit arbitrary behavior for them and fail the verification.